### PR TITLE
Update release binaries to support aarch64 and older glibc versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,23 +7,26 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     strategy:
       matrix:
-        runner: [ubuntu-latest, ubuntu-24.04-arm]
+        target: [x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup rust
         uses: dtolnay/rust-toolchain@stable
       - name: Build
-        run: cargo build --release
+        run: |
+          cargo install cross
+          cross build --release --target ${{ matrix.target }}
       - name: Rename binary
         run: |
           mkdir -p dist
-          cp target/release/pass-secret-service dist/pass-secret-service-$(uname -m)
+          arch=$(echo "${{ matrix.target }}" | cut -d'-' -f1)
+          cp target/${{ matrix.target }}/release/pass-secret-service dist/pass-secret-service-$arch
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,17 +7,24 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: write
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
-      - uses: actions/checkout@v4
-        name: Checkout
-      - uses: dtolnay/rust-toolchain@stable
-        name: Setup rust
-      - run: cargo build --release
-        name: Build
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Build
+        run: cargo build --release
+      - name: Rename binary
+        run: |
+          mkdir -p dist
+          cp target/release/pass-secret-service dist/pass-secret-service-$(uname -m)
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          files: target/release/pass-secret-service
+          files: dist/pass-secret-service-*


### PR DESCRIPTION
Adds `aarch64` binary to make it more convenient to use `pass-secret-service` on ARM64 systems. Also builds with `cross` to lower required Glibc version from 2.39 to 2.31 for better compatibility with older distros (like Debian Bookworm used by `node:lts` Docker image).

See my fork for an example of how the release would look: https://github.com/t1m0thyj/pass-secret-service/releases/tag/v0.4.2

I've tested the resulting binaries in a Docker image:
```
RUN curl -fL https://github.com/t1m0thyj/pass-secret-service/releases/download/v0.4.2/pass-secret-service-$(uname -m) -o /usr/local/bin/pass-secret-service && chmod +x /usr/local/bin/pass-secret-service
```