### PR TITLE
Fix: add .truncate(true) when writing items to prevent GPG decrypt failures

### DIFF
--- a/src/pass.rs
+++ b/src/pass.rs
@@ -182,6 +182,7 @@ impl PasswordStore {
             let mut file = OpenOptions::new()
                 .write(true)
                 .create(true)
+                .truncate(true)
                 .mode(self.file_mode)
                 .open(full_path)
                 .await?;


### PR DESCRIPTION
When updating an existing secret, the service opened the target file with create(true) but without truncate(true). If the new ciphertext was smaller than the previous one, stale trailing bytes remained on disk. This produced corrupted .gpg files and runtime failures like:

```
gpg: gcry_cipher_checktag failed: Checksum error
gpg: [don't know]: invalid packet (ctb=00)

```

This PR adds .truncate(true) to the OpenOptions used for writes so the file is correctly truncated before writing the new ciphertext.