### PR TITLE
feat(systemd): add install section and restart on failure

### DIFF
--- a/systemd/pass-secret-service.service
+++ b/systemd/pass-secret-service.service
@@ -6,3 +6,7 @@ PartOf=graphical-session.target
 Type=dbus
 BusName=org.freedesktop.secrets
 ExecStart=/usr/bin/pass-secret-service
+Restart=on-failure
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Adds a `[Install]` section to the systemd service unit, allowing the service to be enabled to start at boot using `systemctl enable`.

Also, sets `Restart=on-failure` to automatically restart the service if it exits with a non-zero status, improving its robustness.