### PR TITLE
feat: send notification on secret access

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A systemd user unit and a D-Bus session activation file are located in the `syst
 ## Usage
 
 ```
-Usage: pass-secret-service [-d <path>] [-f] [-V] [--log-level <log-level>] [<command>] [<args>]
+Usage: pass-secret-service [-d <path>] [-f] [-n] [-V] [--log-level <log-level>] [<command>] [<args>]
 
 Background daemon for pass-secret-service: An implementation of org.freedesktop.secrets using pass
 
@@ -37,6 +37,9 @@ Options:
   -f, --forget-password-on-lock
                     make gpg-agent forget the cached key password when any
                     collection is locked
+  -n, --notify-on-access
+                    send a desktop notification via org.freedesktop.Notifications
+                    whenever a secret is accessed
   -V, --version     print the current version
   --log-level       log level (overridden by $RUST_LOG environment variable)
                     uses env_logger syntax
@@ -48,6 +51,15 @@ Commands:
 ```
 
 The subcommand is optional; ommitting it defaults to `run-service`.
+
+### Access notifications (`--notify-on-access`)
+
+Pass `-n` / `--notify-on-access` to send a desktop notification via `org.freedesktop.Notifications` every time a secret value is read. Each notification includes the secret label, the accessing application name, its PID, and UID.
+
+```sh
+pass-secret-service -n
+pass-secret-service run-service --notify-on-access
+```
 
 ### Getting the last secret accessor (#20)
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ pass-secret-service -n
 pass-secret-service run-service --notify-on-access
 ```
 
+With systemd D-Bus activation, this can be configured with a drop in:
+```sh
+systemctl --user edit pass-secret-service.service
+```
+
+```toml
+[Service]
+ExecStart=
+ExecStart=/usr/bin/pass-secret-service -n
+```
+
 ### Getting the last secret accessor (#20)
 
 The service stores information about the last accessor for each secret in memory.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,10 @@ pub struct CliArgs {
     #[argh(switch, short = 'f')]
     pub forget_password_on_lock: bool,
 
+    /// send a desktop notification via org.freedesktop.Notifications whenever a secret is accessed
+    #[argh(switch, short = 'n', long = "notify-on-access")]
+    pub notify_on_access: bool,
+
     /// print the current version
     #[argh(switch, short = 'V', long = "version")]
     pub print_version: bool,

--- a/src/dbus_server/collection.rs
+++ b/src/dbus_server/collection.rs
@@ -29,6 +29,7 @@ use super::{
 pub struct Collection<'a> {
     pub store: Box<dyn SecretStore<'a> + Send + Sync>,
     pub id: Arc<String>,
+    pub notify_on_access: bool,
 }
 
 impl<'a> Collection<'a> {
@@ -37,7 +38,8 @@ impl<'a> Collection<'a> {
             id: Arc::new(id),
             collection_id: self.id.clone(),
             store: clone_box(self.store.as_ref()),
-            last_access: Default::default()
+            last_access: Default::default(),
+            notify_on_access: self.notify_on_access,
         }
     }
 

--- a/src/dbus_server/item.rs
+++ b/src/dbus_server/item.rs
@@ -134,19 +134,18 @@ impl<'a> Item<'a> {
         } else {
             None
         };
-        *self.last_access.write().await = access_info;
 
         // send desktop notification if enabled
         if self.notify_on_access {
-            if let Some(accessor) = self.last_access.read().await.as_ref() {
-                let label = self
-                    .store
-                    .get_secret_label(self.collection_id.clone(), self.id.clone())
-                    .await
-                    .unwrap_or_else(|_| self.id.to_string());
-                send_access_notification(connection, &label, accessor).await;
-            }
+            let label = self
+                .store
+                .get_secret_label(self.collection_id.clone(), self.id.clone())
+                .await
+                .unwrap_or_else(|_| self.id.to_string());
+            send_access_notification(connection, &label, access_info.as_ref()).await;
         }
+        
+        *self.last_access.write().await = access_info;
 
         session.encrypt(secret_value, header)
     }
@@ -155,18 +154,23 @@ impl<'a> Item<'a> {
 async fn send_access_notification(
     connection: &Connection,
     label: &str,
-    accessor: &SecretAccessor<'_>,
+    accessor: Option<&SecretAccessor<'_>>,
 ) {
-    let process = accessor
-        .process_name
-        .as_ref()
-        .map(|s| s.as_str())
-        .unwrap_or("<unknown>");
     let summary = format!("Secret '{}' accessed", label);
-    let body = format!(
-        "Application <b>{}</b> (PID {}, UID {}) accessed this secret.",
-        process, accessor.pid, accessor.uid
-    );
+    let body = if let Some(accessor) = accessor {
+        let process = accessor
+            .process_name
+            .as_ref()
+            .map(|s| s.as_str())
+            .unwrap_or("<unknown>");
+        format!(
+            "Application <b>{}</b> (PID {}, UID {}) accessed this secret.",
+            process, accessor.pid, accessor.uid
+        )
+    } else {
+        // We don't know anything about the accessor
+        "An unknown application accessed this secret".into()
+    };
     let actions: Vec<&str> = vec![];
     let hints: HashMap<&str, Value<'_>> = HashMap::new();
 

--- a/src/dbus_server/item.rs
+++ b/src/dbus_server/item.rs
@@ -1,12 +1,12 @@
 use jiff::Timestamp;
-use log::debug;
+use log::{debug, warn};
 use serde::{Deserialize, Serialize};
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 use tokio::{sync::RwLock, task::spawn_blocking};
 use std::{collections::HashMap, sync::Arc};
 
 use zbus::{
-    Connection, ObjectServer, fdo::{self, DBusProxy}, interface, message::Header, names::{BusName, UniqueName}, object_server::InterfaceDeref, zvariant::{ObjectPath, Optional, Type}
+    Connection, ObjectServer, fdo::{self, DBusProxy}, interface, message::Header, names::{BusName, UniqueName}, object_server::InterfaceDeref, zvariant::{ObjectPath, Optional, Type, Value}
 };
 
 use crate::{
@@ -88,6 +88,7 @@ pub struct Item<'a> {
     pub id: Arc<String>,
     pub store: Box<dyn SecretStore<'a> + Send + Sync>,
     pub last_access: Arc<RwLock<Option<SecretAccessor<'static>>>>,
+    pub notify_on_access: bool,
 }
 
 impl<'a> Item<'a> {
@@ -135,7 +136,51 @@ impl<'a> Item<'a> {
         };
         *self.last_access.write().await = access_info;
 
+        // send desktop notification if enabled
+        if self.notify_on_access {
+            if let Some(accessor) = self.last_access.read().await.as_ref() {
+                let label = self
+                    .store
+                    .get_secret_label(self.collection_id.clone(), self.id.clone())
+                    .await
+                    .unwrap_or_else(|_| self.id.to_string());
+                send_access_notification(connection, &label, accessor).await;
+            }
+        }
+
         session.encrypt(secret_value, header)
+    }
+}
+
+async fn send_access_notification(
+    connection: &Connection,
+    label: &str,
+    accessor: &SecretAccessor<'_>,
+) {
+    let process = accessor
+        .process_name
+        .as_ref()
+        .map(|s| s.as_str())
+        .unwrap_or("<unknown>");
+    let summary = format!("Secret '{}' accessed", label);
+    let body = format!(
+        "Application <b>{}</b> (PID {}, UID {}) accessed this secret.",
+        process, accessor.pid, accessor.uid
+    );
+    let actions: Vec<&str> = vec![];
+    let hints: HashMap<&str, Value<'_>> = HashMap::new();
+
+    if let Err(e) = connection
+        .call_method(
+            Some("org.freedesktop.Notifications"),
+            "/org/freedesktop/Notifications",
+            Some("org.freedesktop.Notifications"),
+            "Notify",
+            &("pass-secret-service", 0u32, "dialog-password", summary.as_str(), body.as_str(), actions, hints, -1i32),
+        )
+        .await
+    {
+        warn!("Failed to send access notification: {}", e);
     }
 }
 

--- a/src/dbus_server/service.rs
+++ b/src/dbus_server/service.rs
@@ -42,6 +42,7 @@ pub const DEFAULT_COLLECTION_NAME: &'static str = "default";
 pub struct Service<'a> {
     store: Box<dyn SecretStore<'a> + Send + Sync>,
     forget_password_on_lock: bool,
+    notify_on_access: bool,
 }
 
 impl Service<'static> {
@@ -49,6 +50,7 @@ impl Service<'static> {
         connection: Connection,
         pass: &'static PasswordStore,
         forget_password_on_lock: bool,
+        notify_on_access: bool,
     ) -> Result<Self> {
         let store = Box::new(RedbSecretStore::new(pass).await?);
 
@@ -80,7 +82,8 @@ impl Service<'static> {
                         store: store.clone(),
                         id: Arc::new(id),
                         collection_id: collection_id.clone(),
-                        last_access: Default::default()
+                        last_access: Default::default(),
+                        notify_on_access,
                     })
                     .collect();
 
@@ -94,6 +97,7 @@ impl Service<'static> {
                 let c = Collection {
                     store: store.clone(),
                     id: collection_id,
+                    notify_on_access,
                 };
 
                 // add the aliases
@@ -116,6 +120,7 @@ impl Service<'static> {
         Ok(Service {
             store,
             forget_password_on_lock,
+            notify_on_access,
         })
     }
 
@@ -123,6 +128,7 @@ impl Service<'static> {
         Collection {
             id: Arc::new(name),
             store: clone_box(self.store.as_ref()),
+            notify_on_access: self.notify_on_access,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ async fn run(args: CliArgs) -> Result {
                 connection.unique_name().map(|s| s.as_str()).unwrap_or("?")
             );
         
-            let service = Service::init(connection.clone(), pass, args.forget_password_on_lock).await?;
+            let service = Service::init(connection.clone(), pass, args.forget_password_on_lock, args.notify_on_access).await?;
         
             connection
                 .object_server()


### PR DESCRIPTION
Adds new option `-n|--notify-on-access` to send notification to user using freedesktop notification service whenever secrets are accessed.
Implements what https://github.com/grimsteel/pass-secret-service/issues/20#issuecomment-3831703309 referenced to.
