### PR TITLE
move setup to binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.antigravitycli

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,6 +1426,7 @@ dependencies = [
  "sysinfo",
  "thiserror",
  "tokio",
+ "uuid",
  "zbus",
 ]
 
@@ -2219,6 +2220,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,6 +1161,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "memsec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c797b9d6bb23aab2fc369c65f871be49214f5c759af65bde26ffaaa2b646b492"
+dependencies = [
+ "getrandom 0.2.15",
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,13 +1419,13 @@ dependencies = [
  "redb",
  "rsa",
  "schemars",
+ "secure-types",
  "serde",
  "serde_json",
  "sha2",
  "sysinfo",
  "thiserror",
  "tokio",
- "uuid",
  "zbus",
 ]
 
@@ -1765,6 +1776,19 @@ dependencies = [
  "quote",
  "serde_derive_internals",
  "syn",
+]
+
+[[package]]
+name = "secure-types"
+version = "0.2.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5366218695b48cb7a377df34c70bed20ee1319138ad5a5ba95135d460e28ace"
+dependencies = [
+ "libc",
+ "memsec",
+ "serde",
+ "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -2197,17 +2221,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "uuid"
-version = "1.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
-dependencies = [
- "getrandom 0.4.2",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,6 +2470,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -2480,6 +2502,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2541,6 +2578,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -2559,6 +2602,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -2574,6 +2623,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2607,6 +2662,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -2622,6 +2683,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2643,6 +2710,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -2658,6 +2731,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +36,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -383,7 +407,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -578,6 +612,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -895,6 +939,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +965,7 @@ name = "pass-secret-service"
 version = "0.7.0"
 dependencies = [
  "aes",
+ "aes-gcm",
  "argh",
  "async-trait",
  "cbc",
@@ -974,6 +1025,18 @@ dependencies = [
  "rustix",
  "tracing",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -1396,6 +1459,16 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "generic-array",
 ]
 
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.12",
 ]
 
 [[package]]
@@ -50,6 +50,19 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -110,6 +123,12 @@ dependencies = [
  "once_cell_polyfill",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "argh"
@@ -276,6 +295,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +362,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +386,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -326,6 +418,21 @@ dependencies = [
  "futures-lite",
  "piper",
 ]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -361,12 +468,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
 ]
 
@@ -386,10 +504,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -407,8 +546,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -421,14 +569,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuid-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d59a706635108a7e8eaae7ec8e6154504fafa4a415ef38690d94fccea051757"
+
+[[package]]
+name = "cuid2"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71de6c6a14e38eeae421efba9a6e94631cd84cbb15fd42c9c15abfc45460ba6b"
+dependencies = [
+ "ahash",
+ "cuid-util",
+ "getrandom 0.3.4",
+ "getrandom 0.4.2",
+ "num",
+ "rand 0.10.1",
+ "sha3",
+ "web-time",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -531,6 +724,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,6 +823,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "ghash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,9 +870,24 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -669,17 +922,115 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.2.6"
+name = "http"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower 0.4.13",
+ "tower-service",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -715,7 +1066,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -730,10 +1081,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -746,6 +1138,12 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
@@ -761,6 +1159,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -788,7 +1192,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -835,7 +1239,23 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -845,7 +1265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -886,6 +1306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -968,7 +1389,11 @@ dependencies = [
  "aes-gcm",
  "argh",
  "async-trait",
+ "axum",
+ "base64",
+ "bs58",
  "cbc",
+ "cuid2",
  "dyn-clone",
  "env_logger",
  "futures-util",
@@ -978,15 +1403,54 @@ dependencies = [
  "log",
  "nanoid",
  "num",
- "rand",
+ "qrcode",
+ "rand 0.8.5",
  "redb",
+ "rsa",
+ "schemars",
  "serde",
  "serde_json",
  "sha2",
  "sysinfo",
  "thiserror",
  "tokio",
+ "uuid",
  "zbus",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1013,6 +1477,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "polling"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,7 +1519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.12",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1061,6 +1546,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1574,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1589,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,7 +1608,18 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1105,7 +1629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1114,8 +1638,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redb"
@@ -1156,6 +1686,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rust-fuzzy-search"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,10 +1732,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1217,6 +1804,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,6 +1823,17 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
  "serde",
  "serde_core",
 ]
@@ -1247,8 +1856,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.12",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1258,8 +1867,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.12",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
 ]
 
 [[package]]
@@ -1272,6 +1891,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1910,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1923,22 @@ checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -1312,6 +1963,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "sysinfo"
@@ -1358,6 +2015,21 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1407,6 +2079,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uds_windows"
@@ -1461,12 +2175,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -1475,6 +2195,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"
@@ -1487,6 +2218,113 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -1849,6 +2687,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "xdg-home"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,7 +2808,7 @@ dependencies = [
  "hex",
  "nix",
  "ordered-stream",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "sha1",
@@ -1914,6 +2846,32 @@ dependencies = [
  "static_assertions",
  "zvariant",
 ]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zvariant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,11 @@ aes = "0.8.4"
 aes-gcm = "0.10.3"
 argh = "0.1.13"
 async-trait = "0.1.89"
+axum = { version = "0.7.9", default-features = false, features = ["http1", "json", "tokio"] }
+base64 = "0.22.1"
+bs58 = "0.5.1"
 cbc = { version = "0.1.2", features = ["std"] }
+cuid2 = "0.1.6"
 dyn-clone = "1.0.20"
 env_logger = "0.11.8"
 futures-util = "0.3.30"
@@ -19,13 +23,17 @@ log = "0.4.27"
 nanoid = "0.4.0"
 num = { version = "0.4.3", features = ["rand"] }
 rand = "0.8.5"
+qrcode = { version = "0.14.1", default-features = false }
 redb = "2.1.1"
+rsa = { version = "0.9.10", features = ["sha2"] }
+schemars = "0.8.22"
 serde = "1.0.204"
 serde_json = "1.0.145"
 sha2 = "0.10.9"
 sysinfo = { version = "0.38.0", default-features = false, features = ["system"] }
 thiserror = "2.0.12"
-tokio = { version = "1.38.1", features = ["fs", "rt", "rt-multi-thread", "macros", "process", "sync"] }
+tokio = { version = "1.38.1", features = ["fs", "rt", "rt-multi-thread", "macros", "net", "process", "sync"] }
+uuid = { version = "1.23.2", features = ["v4"] }
 zbus = { version = "4.3.1", default-features = false, features = ["tokio"] }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 aes = "0.8.4"
+aes-gcm = "0.10.3"
 argh = "0.1.13"
 async-trait = "0.1.89"
 cbc = { version = "0.1.2", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,13 @@ qrcode = { version = "0.14.1", default-features = false }
 redb = "2.1.1"
 rsa = { version = "0.9.10", features = ["sha2"] }
 schemars = "0.8.22"
+secure-types = { version = "0.2.40", features = ["serde"] }
 serde = "1.0.204"
 serde_json = "1.0.145"
 sha2 = "0.10.9"
 sysinfo = { version = "0.38.0", default-features = false, features = ["system"] }
 thiserror = "2.0.12"
 tokio = { version = "1.38.1", features = ["fs", "rt", "rt-multi-thread", "macros", "net", "process", "sync"] }
-uuid = { version = "1.23.2", features = ["v4"] }
 zbus = { version = "4.3.1", default-features = false, features = ["tokio"] }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,18 @@ name = "pass-secret-service"
 version = "0.7.0"
 edition = "2021"
 
+[lib]
+name = "pass_secret_service"
+path = "src/lib.rs"
+
+[[bin]]
+name = "pass-secret-service"
+path = "src/main.rs"
+
+[[bin]]
+name = "alohomora-setup"
+path = "src/bin/setup.rs"
+
 [dependencies]
 aes = "0.8.4"
 aes-gcm = "0.10.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ serde_json = "1.0.145"
 sha2 = "0.10.9"
 sysinfo = { version = "0.38.0", default-features = false, features = ["system"] }
 thiserror = "2.0.12"
-tokio = { version = "1.38.1", features = ["fs", "rt", "rt-multi-thread", "macros", "net", "process", "sync"] }
+tokio = { version = "1.38.1", features = ["fs", "rt", "rt-multi-thread", "macros", "net", "process", "sync", "time"] }
+uuid = { version = "1.11.0", features = ["v4"] }
 zbus = { version = "4.3.1", default-features = false, features = ["tokio"] }
 
 [profile.release]

--- a/src/auth_gate.rs
+++ b/src/auth_gate.rs
@@ -1,0 +1,165 @@
+use std::{collections::HashMap, fmt, sync::Arc, time::Duration};
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use log::{debug, info, warn};
+use serde::Serialize;
+use tokio::{
+    sync::{oneshot, Mutex},
+    time,
+};
+use uuid::Uuid;
+
+use crate::{
+    config::AppConfig,
+    dbus_server::SecretAccessor,
+    error::{Error, Result},
+    key_store::{self, SecureKey},
+};
+
+const AUTHORIZATION_TIMEOUT: Duration = Duration::from_secs(60);
+
+#[derive(Clone)]
+pub struct AuthGate {
+    inner: Arc<AuthGateInner>,
+}
+
+impl fmt::Debug for AuthGate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AuthGate")
+            .field("domain", &self.inner.domain)
+            .field("external_port", &self.inner.external_port)
+            .finish_non_exhaustive()
+    }
+}
+
+struct AuthGateInner {
+    local_key: SecureKey,
+    domain: String,
+    external_port: u16,
+    pending: Mutex<HashMap<String, oneshot::Sender<SecureKey>>>,
+}
+
+#[derive(Debug, Serialize)]
+struct AndroidAuthPayload {
+    request_uuid: String,
+    encrypted_blob: String,
+    uid: String,
+    username: String,
+    pid: String,
+    process_name: String,
+    access_timestamp_ms: String,
+    domain: String,
+    port: String,
+}
+
+impl AuthGate {
+    pub fn new(config: &AppConfig, local_key: SecureKey) -> Self {
+        Self {
+            inner: Arc::new(AuthGateInner {
+                local_key,
+                domain: config.domain.clone(),
+                external_port: config.external_port,
+                pending: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    pub fn local_key(&self) -> &SecureKey {
+        &self.inner.local_key
+    }
+
+    pub async fn request_secret_key(
+        &self,
+        accessor: Option<&SecretAccessor<'_>>,
+    ) -> Result<SecureKey> {
+        let devices = key_store::list_android_device_auth_blobs().await?;
+        if devices.is_empty() {
+            warn!("Secret access requested but no Android devices are registered");
+            return Err(Error::PermissionDenied);
+        }
+
+        let request_uuid = Uuid::new_v4().to_string();
+        let (sender, receiver) = oneshot::channel();
+
+        {
+            let mut pending = self.inner.pending.lock().await;
+            pending.insert(request_uuid.clone(), sender);
+        }
+
+        for device in devices {
+            let encrypted_blob = device
+                .encrypted_secret_key
+                .unlock_slice(|encrypted| BASE64.encode(encrypted));
+            let payload = AndroidAuthPayload {
+                request_uuid: request_uuid.clone(),
+                encrypted_blob,
+                uid: accessor.map(|a| a.uid).unwrap_or_default().to_string(),
+                username: optional_string(accessor.and_then(|a| a.username.as_ref())),
+                pid: accessor.map(|a| a.pid).unwrap_or_default().to_string(),
+                process_name: optional_string(accessor.and_then(|a| a.process_name.as_ref())),
+                access_timestamp_ms: accessor
+                    .map(|a| a.timestamp)
+                    .unwrap_or_default()
+                    .to_string(),
+                domain: self.inner.domain.clone(),
+                port: self.inner.external_port.to_string(),
+            };
+
+            match serde_json::to_string(&payload) {
+                Ok(payload) => info!(
+                    "Prepared Android auth payload for device {}: {}",
+                    device.device_uuid, payload
+                ),
+                Err(err) => warn!(
+                    "Failed to serialize Android auth payload for device {}: {}",
+                    device.device_uuid, err
+                ),
+            }
+        }
+
+        match time::timeout(AUTHORIZATION_TIMEOUT, receiver).await {
+            Ok(Ok(secret_key)) => {
+                debug!("Authentication gate opened for request {request_uuid}");
+                Ok(secret_key)
+            }
+            Ok(Err(_)) => {
+                self.inner.pending.lock().await.remove(&request_uuid);
+                Err(Error::PermissionDenied)
+            }
+            Err(_) => {
+                self.inner.pending.lock().await.remove(&request_uuid);
+                warn!("Authentication request {request_uuid} timed out");
+                Err(Error::PermissionDenied)
+            }
+        }
+    }
+
+    pub async fn complete_authentication(
+        &self,
+        request_uuid: &str,
+        decrypted_blob_b64: &str,
+    ) -> Result {
+        let locally_encrypted = BASE64
+            .decode(decrypted_blob_b64)
+            .map_err(|_| Error::InvalidRequest("decrypted_blob_b64 is not valid base64".into()))?;
+        let secret_key = key_store::decrypt_aes256_gcm(&self.inner.local_key, &locally_encrypted)?;
+        let secret_key = SecureKey::try_from(secret_key)
+            .map_err(|_| Error::EncryptionError("decrypted secret key must be 32 bytes"))?;
+
+        let sender = self
+            .inner
+            .pending
+            .lock()
+            .await
+            .remove(request_uuid)
+            .ok_or_else(|| Error::InvalidRequest("no pending authentication request".into()))?;
+
+        sender
+            .send(secret_key)
+            .map_err(|_| Error::InvalidRequest("authentication request is no longer active".into()))
+    }
+}
+
+fn optional_string(value: Option<&String>) -> String {
+    value.cloned().unwrap_or_default()
+}

--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -58,7 +58,32 @@ async fn main() -> ExitCode {
     };
 
     match key_store::run_setup(&config).await {
-        Ok(_) => ExitCode::SUCCESS,
+        Ok(true) => {
+            let key_dir = key_store::get_key_dir();
+            let local_key_path = key_dir.join(key_store::LOCAL_KEY_FILE);
+            let local_key = match key_store::read_local_key(&local_key_path).await {
+                Ok(Some(key)) => key,
+                _ => {
+                    eprintln!("Error: local key not found after setup.");
+                    return ExitCode::FAILURE;
+                }
+            };
+
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            match pass_secret_service::http_server::spawn_setup_server(config, local_key, tx).await {
+                Ok(_server_handle) => {
+                    println!("Waiting for Android device registration...");
+                    let _ = rx.await;
+                    println!("Registration successful! Setup completed successfully.");
+                    ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("Error starting registration server: {}", e);
+                    ExitCode::FAILURE
+                }
+            }
+        }
+        Ok(false) => ExitCode::SUCCESS,
         Err(e) => {
             eprintln!("Setup error: {}", e);
             ExitCode::FAILURE

--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -1,0 +1,23 @@
+use std::process::ExitCode;
+use pass_secret_service::{config, key_store};
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let config = match config::AppConfig::from_env() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Configuration error: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match key_store::run_setup(&config).await {
+        Ok(_) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("Setup error: {}", e);
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -1,9 +1,53 @@
+use std::io::{self, Write};
 use std::process::ExitCode;
 use pass_secret_service::{config, key_store};
+
+#[derive(argh::FromArgs)]
+/// Setup tool for alohomora-service
+struct SetupArgs {
+    /// clear existing setup state and secret store files
+    #[argh(switch, long = "clear")]
+    clear: bool,
+}
+
+fn confirm_clear() -> bool {
+    let expected = "I want to clear my secret store";
+    println!("WARNING: This will permanently delete your local setup keys, device pairing state, and stored secrets!");
+    print!("Please type the following sentence to confirm:\n  \"{}\"\n> ", expected);
+    let _ = io::stdout().flush();
+
+    let mut input = String::new();
+    if io::stdin().read_line(&mut input).is_ok() {
+        if input.trim() == expected {
+            return true;
+        }
+    }
+    false
+}
 
 #[tokio::main]
 async fn main() -> ExitCode {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let args: SetupArgs = argh::from_env();
+
+    if args.clear {
+        if !confirm_clear() {
+            eprintln!("Confirmation failed. Action aborted.");
+            return ExitCode::FAILURE;
+        }
+
+        match key_store::clear_secret_store().await {
+            Ok(_) => {
+                println!("Secret store cleared successfully.");
+                return ExitCode::SUCCESS;
+            }
+            Err(e) => {
+                eprintln!("Error clearing secret store: {}", e);
+                return ExitCode::FAILURE;
+            }
+        }
+    }
 
     let config = match config::AppConfig::from_env() {
         Ok(c) => c,

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use crate::error::{Error, Result};
 
-const DEFAULT_DOMAIN: &str = "lukegt.com";
+const DEFAULT_DOMAIN: &str = "agent.lukegt.com";
 const DEFAULT_PORT: u16 = 19969;
 
 #[derive(Debug, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,36 @@
+use std::env;
+
+use crate::error::{Error, Result};
+
+const DEFAULT_DOMAIN: &str = "lukegt.com";
+const DEFAULT_PORT: u16 = 19969;
+
+#[derive(Debug, Clone)]
+pub struct AppConfig {
+    pub domain: String,
+    pub external_port: u16,
+    pub internal_port: u16,
+}
+
+impl AppConfig {
+    pub fn from_env() -> Result<Self> {
+        let domain = env::var("ALOHOMORA_DOMAIN").unwrap_or_else(|_| DEFAULT_DOMAIN.into());
+        let external_port = read_port_env("ALOHOMORA_EXTERNAL_PORT")?;
+        let internal_port = read_port_env("ALOHOMORA_INTERNAL_PORT")?;
+
+        Ok(Self {
+            domain,
+            external_port,
+            internal_port,
+        })
+    }
+}
+
+fn read_port_env(name: &str) -> Result<u16> {
+    match env::var(name) {
+        Ok(value) => value
+            .parse::<u16>()
+            .map_err(|_| Error::ConfigError(format!("{name} must be a valid u16, got `{value}`"))),
+        Err(_) => Ok(DEFAULT_PORT),
+    }
+}

--- a/src/dbus_server/collection.rs
+++ b/src/dbus_server/collection.rs
@@ -11,6 +11,7 @@ use zbus::{
 };
 
 use crate::{
+    auth_gate::AuthGate,
     dbus_server::secret_transfer::Secret,
     error::{Error, Result},
     secret_store::SecretStore,
@@ -29,6 +30,7 @@ use super::{
 pub struct Collection<'a> {
     pub store: Box<dyn SecretStore<'a> + Send + Sync>,
     pub id: Arc<String>,
+    pub auth_gate: AuthGate,
     pub notify_on_access: bool,
 }
 
@@ -38,6 +40,7 @@ impl<'a> Collection<'a> {
             id: Arc::new(id),
             collection_id: self.id.clone(),
             store: clone_box(self.store.as_ref()),
+            auth_gate: self.auth_gate.clone(),
             last_access: Default::default(),
             notify_on_access: self.notify_on_access,
         }

--- a/src/dbus_server/item.rs
+++ b/src/dbus_server/item.rs
@@ -1,7 +1,7 @@
 use jiff::Timestamp;
 use log::{debug, warn};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, ffi::CStr, mem::MaybeUninit, ptr, sync::Arc};
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 use tokio::{sync::RwLock, task::spawn_blocking};
 
@@ -33,6 +33,7 @@ pub struct SecretAccessor<'a> {
     #[serde(borrow)]
     pub dbus_name: Optional<UniqueName<'a>>,
     pub uid: u32,
+    pub username: Optional<String>,
     pub pid: u32,
     pub process_name: Optional<String>,
     // ms since epoch
@@ -44,11 +45,48 @@ impl<'a> Default for SecretAccessor<'a> {
         Self {
             dbus_name: Optional::from(None),
             uid: 0,
+            username: Optional::from(None),
             pid: 0,
             timestamp: 0,
             process_name: Optional::from(None),
         }
     }
+}
+
+fn username_from_uid(uid: u32) -> Option<String> {
+    let buffer_len = unsafe {
+        match libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) {
+            n if n > 0 => n as usize,
+            _ => 16_384,
+        }
+    };
+    let mut passwd = MaybeUninit::<libc::passwd>::uninit();
+    let mut result = ptr::null_mut();
+    let mut buffer = vec![0 as libc::c_char; buffer_len];
+
+    let status = unsafe {
+        libc::getpwuid_r(
+            uid as libc::uid_t,
+            passwd.as_mut_ptr(),
+            buffer.as_mut_ptr(),
+            buffer.len(),
+            &mut result,
+        )
+    };
+
+    if status != 0 || result.is_null() {
+        return None;
+    }
+
+    let passwd = unsafe { passwd.assume_init() };
+    if passwd.pw_name.is_null() {
+        return None;
+    }
+
+    unsafe { CStr::from_ptr(passwd.pw_name) }
+        .to_str()
+        .ok()
+        .map(str::to_owned)
 }
 
 impl SecretAccessor<'static> {
@@ -71,6 +109,11 @@ impl SecretAccessor<'static> {
             .await
             .map_err(zbus::Error::from)?;
 
+        let username = spawn_blocking(move || username_from_uid(uid))
+            .await
+            .unwrap()
+            .into();
+
         let process_name = spawn_blocking(move || {
             // fetch process info
             let mut system = System::new();
@@ -92,6 +135,7 @@ impl SecretAccessor<'static> {
 
         Ok(Self {
             uid,
+            username,
             pid,
             dbus_name: Optional::from(Some(name)),
             timestamp: Timestamp::now().as_millisecond(),
@@ -181,9 +225,14 @@ async fn send_access_notification(
             .as_ref()
             .map(|s| s.as_str())
             .unwrap_or("<unknown>");
+        let user = accessor
+            .username
+            .as_ref()
+            .map(|s| format!("{} (UID {})", s, accessor.uid))
+            .unwrap_or_else(|| format!("UID {}", accessor.uid));
         format!(
-            "Application <b>{}</b> (PID {}, UID {}) accessed this secret.",
-            process, accessor.pid, accessor.uid
+            "Application <b>{}</b> (PID {}, {}) accessed this secret.",
+            process, accessor.pid, user
         )
     } else {
         // We don't know anything about the accessor

--- a/src/dbus_server/item.rs
+++ b/src/dbus_server/item.rs
@@ -16,8 +16,10 @@ use zbus::{
 };
 
 use crate::{
+    auth_gate::AuthGate,
     dbus_server::collection::Collection,
     error::{Error, Result},
+    key_store::SecureKey,
     secret_store::SecretStore,
 };
 
@@ -149,6 +151,7 @@ pub struct Item<'a> {
     pub collection_id: Arc<String>,
     pub id: Arc<String>,
     pub store: Box<dyn SecretStore<'a> + Send + Sync>,
+    pub auth_gate: AuthGate,
     pub last_access: Arc<RwLock<Option<SecretAccessor<'static>>>>,
     pub notify_on_access: bool,
 }
@@ -175,6 +178,24 @@ impl<'a> Item<'a> {
         session: &InterfaceDeref<'_, Session>,
         connection: &Connection,
     ) -> Result<Secret> {
+        let access_info = access_info_from_header(header, connection).await?;
+        let secret_key = self
+            .auth_gate
+            .request_secret_key(access_info.as_ref())
+            .await?;
+
+        self.read_with_session_and_key(header, session, connection, &secret_key, access_info)
+            .await
+    }
+
+    pub async fn read_with_session_and_key(
+        &self,
+        header: &Header<'_>,
+        session: &InterfaceDeref<'_, Session>,
+        connection: &Connection,
+        secret_key: &SecureKey,
+        access_info: Option<SecretAccessor<'static>>,
+    ) -> Result<Secret> {
         debug!(
             "Fetching secret {}/{} for {}",
             self.collection_id,
@@ -187,15 +208,8 @@ impl<'a> Item<'a> {
 
         let secret_value = self
             .store
-            .read_secret(&*self.collection_id, &*self.id, true)
+            .read_secret_with_key(&*self.collection_id, &*self.id, secret_key)
             .await?;
-
-        // update fetch access info
-        let access_info = if let Some(id) = header.sender() {
-            Some(SecretAccessor::from_dbus_name(connection, id).await?)
-        } else {
-            None
-        };
 
         // send desktop notification if enabled
         if self.notify_on_access {
@@ -210,6 +224,17 @@ impl<'a> Item<'a> {
         *self.last_access.write().await = access_info;
 
         session.encrypt(secret_value, header)
+    }
+}
+
+pub(crate) async fn access_info_from_header(
+    header: &Header<'_>,
+    connection: &Connection,
+) -> Result<Option<SecretAccessor<'static>>> {
+    if let Some(id) = header.sender() {
+        Ok(Some(SecretAccessor::from_dbus_name(connection, id).await?))
+    } else {
+        Ok(None)
     }
 }
 

--- a/src/dbus_server/secret_transfer.rs
+++ b/src/dbus_server/secret_transfer.rs
@@ -107,10 +107,8 @@ impl DhIetf1024Sha256Aes128CbcPkcs7Transfer {
         let client_pub_key = BigUint::from_bytes_be(client_pub_key);
 
         // client pubkey ^ priv key % dh prime
-        let shared_secret = to_bytes_be_padded(
-            &client_pub_key.modpow(&priv_key, dh_prime),
-            DH_PRIME_BYTES,
-        );
+        let shared_secret =
+            to_bytes_be_padded(&client_pub_key.modpow(&priv_key, dh_prime), DH_PRIME_BYTES);
 
         // no salt
         let hk = Hkdf::<Sha256>::new(None, &shared_secret[..]);
@@ -172,7 +170,10 @@ mod tests {
     #[test]
     fn pad_preserves_full_width_value() {
         let n = BigUint::from_bytes_be(&[0xAAu8; DH_PRIME_BYTES]);
-        assert_eq!(to_bytes_be_padded(&n, DH_PRIME_BYTES), vec![0xAA; DH_PRIME_BYTES]);
+        assert_eq!(
+            to_bytes_be_padded(&n, DH_PRIME_BYTES),
+            vec![0xAA; DH_PRIME_BYTES]
+        );
     }
 
     #[test]

--- a/src/dbus_server/service.rs
+++ b/src/dbus_server/service.rs
@@ -16,6 +16,7 @@ use zbus::{
 };
 
 use crate::{
+    auth_gate::AuthGate,
     dbus_server::secret_transfer::{DhIetf1024Sha256Aes128CbcPkcs7Transfer, SessionTransfer},
     error::{Error, OptionNoneNotFound, Result},
     pass::PasswordStore,
@@ -26,7 +27,7 @@ use crate::{
 
 use super::{
     collection::Collection,
-    item::Item,
+    item::{access_info_from_header, Item},
     secret_transfer::{PlainTextTransfer, Secret},
     session::Session,
     utils::{
@@ -41,6 +42,7 @@ pub const DEFAULT_COLLECTION_NAME: &'static str = "default";
 #[derive(Debug)]
 pub struct Service<'a> {
     store: Box<dyn SecretStore<'a> + Send + Sync>,
+    auth_gate: AuthGate,
     forget_password_on_lock: bool,
     notify_on_access: bool,
 }
@@ -49,6 +51,7 @@ impl Service<'static> {
     pub async fn init(
         connection: Connection,
         pass: &'static PasswordStore,
+        auth_gate: AuthGate,
         forget_password_on_lock: bool,
         notify_on_access: bool,
     ) -> Result<Self> {
@@ -80,6 +83,7 @@ impl Service<'static> {
                     .into_iter()
                     .map(|id| Item {
                         store: store.clone(),
+                        auth_gate: auth_gate.clone(),
                         id: Arc::new(id),
                         collection_id: collection_id.clone(),
                         last_access: Default::default(),
@@ -97,6 +101,7 @@ impl Service<'static> {
                 let c = Collection {
                     store: store.clone(),
                     id: collection_id,
+                    auth_gate: auth_gate.clone(),
                     notify_on_access,
                 };
 
@@ -119,6 +124,7 @@ impl Service<'static> {
 
         Ok(Service {
             store,
+            auth_gate,
             forget_password_on_lock,
             notify_on_access,
         })
@@ -128,6 +134,7 @@ impl Service<'static> {
         Collection {
             id: Arc::new(name),
             store: clone_box(self.store.as_ref()),
+            auth_gate: self.auth_gate.clone(),
             notify_on_access: self.notify_on_access,
         }
     }
@@ -326,6 +333,14 @@ impl Service<'static> {
         let session_ref = try_interface(object_server.interface::<_, Session>(&session).await)?
             .ok_or(Error::InvalidSession)?;
         let session = session_ref.get().await;
+        if items.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let access_info = access_info_from_header(&header, connection).await?;
+        let secret_key = self
+            .auth_gate
+            .request_secret_key(access_info.as_ref())
+            .await?;
 
         let mut results = HashMap::with_capacity(items.len());
 
@@ -335,7 +350,13 @@ impl Service<'static> {
             let secret = item_ref
                 .get()
                 .await
-                .read_with_session(&header, &session, connection)
+                .read_with_session_and_key(
+                    &header,
+                    &session,
+                    connection,
+                    &secret_key,
+                    access_info.clone(),
+                )
                 .await?;
             results.insert(item_path.into(), secret);
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,10 @@ pub enum Error {
     RedbError(#[from] redb::Error),
     #[error("Secret encryption error: {0}")]
     EncryptionError(&'static str),
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
+    #[error("Invalid request: {0}")]
+    InvalidRequest(String),
     #[error("GPG Error: {0}")]
     GpgError(String),
     #[error("Pass is not initialized")]
@@ -37,6 +41,8 @@ impl DBusError for Error {
             Error::DbusError(e) => msg.build(&(e.to_string(),)),
             Error::RedbError(e) => msg.build(&(e.to_string(),)),
             Error::GpgError(e) => msg.build(&(e,)),
+            Error::ConfigError(e) => msg.build(&(e,)),
+            Error::InvalidRequest(e) => msg.build(&(e,)),
             _ => msg.build(&()),
         }
     }
@@ -50,6 +56,8 @@ impl DBusError for Error {
             Error::DbusError(_) => "org.freedesktop.zbus.Error",
             Error::RedbError(_) => "me.grimsteel.PassSecretService.ReDBError",
             Error::GpgError(_) => "me.grimsteel.PassSecretService.GPGError",
+            Error::ConfigError(_) => "me.grimsteel.PassSecretService.ConfigError",
+            Error::InvalidRequest(_) => "me.grimsteel.PassSecretService.InvalidRequest",
             Error::EncryptionError(_) => "me.grimsteel.PassSecretService.EncryptionError",
             Error::NotInitialized => "me.grimsteel.PassSecretService.PassNotInitialized",
             Error::InvalidSession => "org.freedesktop.Secret.Error.NoSession",
@@ -61,6 +69,8 @@ impl DBusError for Error {
         match self {
             Error::DbusError(zbus::Error::MethodError(_, desc, _)) => desc.as_deref(),
             Error::GpgError(e) => Some(e.as_str()),
+            Error::ConfigError(e) => Some(e.as_str()),
+            Error::InvalidRequest(e) => Some(e.as_str()),
             _ => None,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,8 @@ pub enum Error {
     InvalidSession,
     #[error("Access denied")]
     PermissionDenied,
+    #[error("Setup has not been completed. Please run the alohomora-setup executable.")]
+    SetupIncomplete,
 }
 
 impl DBusError for Error {
@@ -62,11 +64,13 @@ impl DBusError for Error {
             Error::NotInitialized => "me.grimsteel.PassSecretService.PassNotInitialized",
             Error::InvalidSession => "org.freedesktop.Secret.Error.NoSession",
             Error::PermissionDenied => "org.freedesktop.DBus.Error.AccessDenied",
+            Error::SetupIncomplete => "me.grimsteel.PassSecretService.SetupIncomplete",
         })
     }
 
     fn description(&self) -> Option<&str> {
         match self {
+            Error::SetupIncomplete => Some("Setup has not been completed. Please run the alohomora-setup executable."),
             Error::DbusError(zbus::Error::MethodError(_, desc, _)) => desc.as_deref(),
             Error::GpgError(e) => Some(e.as_str()),
             Error::ConfigError(e) => Some(e.as_str()),

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -140,6 +140,12 @@ impl From<Error> for ApiError {
     }
 }
 
+#[derive(Clone)]
+pub struct SetupApiState {
+    local_key: key_store::SecureKey,
+    done_tx: std::sync::Arc<tokio::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>>,
+}
+
 pub async fn spawn(config: AppConfig, auth_gate: AuthGate) -> Result<JoinHandle<()>> {
     let addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, config.internal_port));
     let listener = TcpListener::bind(addr).await?;
@@ -149,7 +155,6 @@ pub async fn spawn(config: AppConfig, auth_gate: AuthGate) -> Result<JoinHandle<
     );
 
     let app = Router::new()
-        .route("/register", post(register))
         .route("/authenticate", post(authenticate))
         .with_state(ApiState { auth_gate });
 
@@ -160,8 +165,36 @@ pub async fn spawn(config: AppConfig, auth_gate: AuthGate) -> Result<JoinHandle<
     }))
 }
 
-async fn register(
-    State(state): State<ApiState>,
+pub async fn spawn_setup_server(
+    config: AppConfig,
+    local_key: key_store::SecureKey,
+    done_tx: tokio::sync::oneshot::Sender<()>,
+) -> Result<JoinHandle<()>> {
+    let addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, config.internal_port));
+    let listener = TcpListener::bind(addr).await?;
+    info!(
+        "Alohomora Setup HTTP server listening on {} for {}:{}",
+        addr, config.domain, config.external_port
+    );
+
+    let state = SetupApiState {
+        local_key,
+        done_tx: std::sync::Arc::new(tokio::sync::Mutex::new(Some(done_tx))),
+    };
+
+    let app = Router::new()
+        .route("/register", post(register_setup))
+        .with_state(state);
+
+    Ok(tokio::spawn(async move {
+        if let Err(err) = axum::serve(listener, app).await {
+            error!("Alohomora Setup HTTP server failed: {err}");
+        }
+    }))
+}
+
+async fn register_setup(
+    State(state): State<SetupApiState>,
     Json(request): Json<RegisterRequest>,
 ) -> std::result::Result<StatusCode, ApiError> {
     debug!(
@@ -186,9 +219,9 @@ async fn register(
     validate_public_key_info(&request.public_key)?;
 
     let secret_key =
-        key_store::read_temp_secret_key(initialisation_token, state.auth_gate.local_key()).await?;
+        key_store::read_temp_secret_key(initialisation_token, &state.local_key).await?;
     let locally_encrypted_secret_key = secret_key.unlock(|secret_key| {
-        key_store::encrypt_aes256_gcm(state.auth_gate.local_key(), secret_key)
+        key_store::encrypt_aes256_gcm(&state.local_key, secret_key)
     })?;
     let encrypted_secret_key = locally_encrypted_secret_key.unlock_slice(|encrypted| {
         encrypt_with_registration_public_key(&request.public_key, encrypted)
@@ -197,7 +230,7 @@ async fn register(
     let registration_json = serde_json::to_vec(&request)
         .map_err(|err| ApiError::internal(format!("failed to serialize registration: {err}")))?;
     let encrypted_registration =
-        key_store::encrypt_aes256_gcm(state.auth_gate.local_key(), &registration_json)?;
+        key_store::encrypt_aes256_gcm(&state.local_key, &registration_json)?;
 
     key_store::store_android_device_registration(
         &request.device_uuid,
@@ -210,6 +243,10 @@ async fn register(
         "Registered Android device {} at device-keys/android/{}",
         request.device.model, request.device_uuid
     );
+
+    if let Some(tx) = state.done_tx.lock().await.take() {
+        let _ = tx.send(());
+    }
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -155,7 +155,7 @@ pub async fn spawn(config: AppConfig, auth_gate: AuthGate) -> Result<JoinHandle<
     );
 
     let app = Router::new()
-        .route("/authenticate", post(authenticate))
+        .route("/alohomora/authenticate", post(authenticate))
         .with_state(ApiState { auth_gate });
 
     Ok(tokio::spawn(async move {
@@ -183,7 +183,7 @@ pub async fn spawn_setup_server(
     };
 
     let app = Router::new()
-        .route("/register", post(register_setup))
+        .route("/alohomora/register", post(register_setup))
         .with_state(state);
 
     Ok(tokio::spawn(async move {

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -1,0 +1,353 @@
+use std::net::{Ipv4Addr, SocketAddr};
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::post,
+    Json, Router,
+};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use log::{debug, error, info};
+use rand::rngs::OsRng;
+use rsa::{pkcs8::DecodePublicKey, sha2::Sha256, Oaep, RsaPublicKey};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::{net::TcpListener, task::JoinHandle};
+use uuid::Uuid;
+
+use crate::{
+    config::AppConfig,
+    error::{Error, Result},
+    key_store::{self, AES256_KEY_BYTES},
+};
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct KeychainInfo {
+    pub domain: String,
+    pub port: u16,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PublicKeyParameters {
+    pub digest: String,
+    pub mgf: String,
+    pub mgf_digest: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PublicKeyInfo {
+    pub algorithm: String,
+    pub format: String,
+    pub value_b64: String,
+    pub parameters: PublicKeyParameters,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct FcmInfo {
+    pub token: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AppInfo {
+    pub package_name: String,
+    pub version_name: String,
+    pub version_code: u32,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct DeviceInfo {
+    pub os: String,
+    pub sdk_int: u32,
+    pub release: String,
+    pub manufacturer: String,
+    pub model: String,
+    pub product: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RegisterRequest {
+    pub schema_version: u32,
+    pub keychain: KeychainInfo,
+    #[serde(default)]
+    pub initialisation_token: Option<String>,
+    pub public_key: PublicKeyInfo,
+    pub fcm: FcmInfo,
+    pub app: AppInfo,
+    pub device: DeviceInfo,
+    pub registered_at_ms: i64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AuthenticateRequest {
+    pub schema_version: u32,
+    pub request_uuid: String,
+    pub keychain: KeychainInfo,
+    pub decrypted_blob_b64: String,
+    pub app: AppInfo,
+    pub approved_at_ms: i64,
+}
+
+#[derive(Clone)]
+struct ApiState {
+    local_key: [u8; AES256_KEY_BYTES],
+}
+
+#[derive(Debug)]
+struct ApiError {
+    status: StatusCode,
+    message: String,
+}
+
+impl ApiError {
+    fn bad_request(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            message: message.into(),
+        }
+    }
+
+    fn internal(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: message.into(),
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        (self.status, self.message).into_response()
+    }
+}
+
+impl From<Error> for ApiError {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::InvalidRequest(message) => Self::bad_request(message),
+            err => Self::internal(err.to_string()),
+        }
+    }
+}
+
+pub async fn spawn(config: AppConfig, local_key: [u8; AES256_KEY_BYTES]) -> Result<JoinHandle<()>> {
+    let addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, config.internal_port));
+    let listener = TcpListener::bind(addr).await?;
+    info!(
+        "Alohomora HTTP server listening on {} for {}:{}",
+        addr, config.domain, config.external_port
+    );
+
+    let app = Router::new()
+        .route("/register", post(register))
+        .route("/authenticate", post(authenticate))
+        .with_state(ApiState { local_key });
+
+    Ok(tokio::spawn(async move {
+        if let Err(err) = axum::serve(listener, app).await {
+            error!("Alohomora HTTP server failed: {err}");
+        }
+    }))
+}
+
+async fn register(
+    State(state): State<ApiState>,
+    Json(request): Json<RegisterRequest>,
+) -> std::result::Result<StatusCode, ApiError> {
+    debug!(
+        "Received registration request for {}:{} from {} {}",
+        request.keychain.domain,
+        request.keychain.port,
+        request.device.manufacturer,
+        request.device.model
+    );
+
+    if request.device.os != "Android" {
+        return Err(ApiError::bad_request(
+            "only Android registrations are supported",
+        ));
+    }
+
+    let initialisation_token = request
+        .initialisation_token
+        .as_deref()
+        .ok_or_else(|| ApiError::bad_request("initialisation_token is required"))?;
+
+    validate_public_key_info(&request.public_key)?;
+
+    let secret_key =
+        key_store::read_temp_secret_key(initialisation_token, &state.local_key).await?;
+    let locally_encrypted_secret_key =
+        key_store::encrypt_aes256_gcm(&state.local_key, &secret_key)?;
+    let encrypted_secret_key =
+        encrypt_with_registration_public_key(&request.public_key, &locally_encrypted_secret_key)?;
+
+    let registration_json = serde_json::to_vec(&request)
+        .map_err(|err| ApiError::internal(format!("failed to serialize registration: {err}")))?;
+    let encrypted_registration =
+        key_store::encrypt_aes256_gcm(&state.local_key, &registration_json)?;
+
+    let device_uuid = Uuid::new_v4().to_string();
+    key_store::store_android_device_registration(
+        &device_uuid,
+        &encrypted_registration,
+        &encrypted_secret_key,
+    )
+    .await?;
+
+    info!(
+        "Registered Android device {} at device-keys/android/{}",
+        request.device.model, device_uuid
+    );
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn authenticate(Json(request): Json<AuthenticateRequest>) -> StatusCode {
+    debug!(
+        "Received authentication approval for request {} from {}",
+        request.request_uuid, request.app.package_name
+    );
+    StatusCode::NO_CONTENT
+}
+
+fn validate_public_key_info(public_key: &PublicKeyInfo) -> std::result::Result<(), ApiError> {
+    if public_key.algorithm != "RSA-OAEP-256" {
+        return Err(ApiError::bad_request(
+            "public_key.algorithm must be RSA-OAEP-256",
+        ));
+    }
+    if public_key.format != "X.509 SubjectPublicKeyInfo" {
+        return Err(ApiError::bad_request(
+            "public_key.format must be X.509 SubjectPublicKeyInfo",
+        ));
+    }
+    if public_key.parameters.digest != "SHA-256"
+        || public_key.parameters.mgf != "MGF1"
+        || public_key.parameters.mgf_digest != "SHA-256"
+    {
+        return Err(ApiError::bad_request(
+            "public_key.parameters must specify SHA-256/MGF1/SHA-256",
+        ));
+    }
+    Ok(())
+}
+
+fn encrypt_with_registration_public_key(
+    public_key: &PublicKeyInfo,
+    plaintext: &[u8],
+) -> std::result::Result<Vec<u8>, ApiError> {
+    let public_key_der = BASE64
+        .decode(&public_key.value_b64)
+        .map_err(|_| ApiError::bad_request("public_key.value_b64 is not valid base64"))?;
+    let public_key = RsaPublicKey::from_public_key_der(&public_key_der)
+        .map_err(|_| ApiError::bad_request("public_key.value_b64 is not a valid SPKI RSA key"))?;
+
+    public_key
+        .encrypt(&mut OsRng, Oaep::new::<Sha256>(), plaintext)
+        .map_err(|err| ApiError::bad_request(format!("RSA-OAEP-256 encryption failed: {err}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use schemars::schema_for;
+
+    use super::{AuthenticateRequest, RegisterRequest};
+
+    #[test]
+    fn register_request_has_json_schema() {
+        let schema = schema_for!(RegisterRequest);
+        assert_eq!(
+            schema.schema.metadata.unwrap().title.unwrap(),
+            "RegisterRequest"
+        );
+    }
+
+    #[test]
+    fn authenticate_request_has_json_schema() {
+        let schema = schema_for!(AuthenticateRequest);
+        assert_eq!(
+            schema.schema.metadata.unwrap().title.unwrap(),
+            "AuthenticateRequest"
+        );
+    }
+
+    #[test]
+    fn register_request_parses_expected_payload() {
+        let payload = r#"{
+            "schema_version": 1,
+            "keychain": {
+              "domain": "example.com",
+              "port": 443
+            },
+            "initialisation_token": "optional-token",
+            "public_key": {
+              "algorithm": "RSA-OAEP-256",
+              "format": "X.509 SubjectPublicKeyInfo",
+              "value_b64": "base64-public-key",
+              "parameters": {
+                "digest": "SHA-256",
+                "mgf": "MGF1",
+                "mgf_digest": "SHA-256"
+              }
+            },
+            "fcm": {
+              "token": "firebase-registration-token"
+            },
+            "app": {
+              "package_name": "com.alohomora.app",
+              "version_name": "0.1.0",
+              "version_code": 1
+            },
+            "device": {
+              "os": "Android",
+              "sdk_int": 36,
+              "release": "16",
+              "manufacturer": "Google",
+              "model": "Pixel",
+              "product": "pixel"
+            },
+            "registered_at_ms": 1760000000000
+        }"#;
+
+        let request: RegisterRequest = serde_json::from_str(payload).unwrap();
+        assert_eq!(request.schema_version, 1);
+        assert_eq!(
+            request.initialisation_token.as_deref(),
+            Some("optional-token")
+        );
+        assert_eq!(request.public_key.parameters.mgf_digest, "SHA-256");
+    }
+
+    #[test]
+    fn authenticate_request_parses_expected_payload() {
+        let payload = r#"{
+            "schema_version": 1,
+            "request_uuid": "6fbbce84-5aef-43c3-8cc7-469cbfd83109",
+            "keychain": {
+              "domain": "example.com",
+              "port": 443
+            },
+            "decrypted_blob_b64": "base64-decrypted-blob",
+            "app": {
+              "package_name": "com.alohomora.app",
+              "version_name": "0.1.0",
+              "version_code": 1
+            },
+            "approved_at_ms": 1760000000123
+        }"#;
+
+        let request: AuthenticateRequest = serde_json::from_str(payload).unwrap();
+        assert_eq!(request.schema_version, 1);
+        assert_eq!(request.request_uuid, "6fbbce84-5aef-43c3-8cc7-469cbfd83109");
+        assert_eq!(request.decrypted_blob_b64, "base64-decrypted-blob");
+    }
+}

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -16,9 +16,10 @@ use serde::{Deserialize, Serialize};
 use tokio::{net::TcpListener, task::JoinHandle};
 
 use crate::{
+    auth_gate::AuthGate,
     config::AppConfig,
     error::{Error, Result},
-    key_store::{self, SecureBlob, SecureKey},
+    key_store::{self, SecureBlob},
 };
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
@@ -99,7 +100,7 @@ pub struct AuthenticateRequest {
 
 #[derive(Clone)]
 struct ApiState {
-    local_key: SecureKey,
+    auth_gate: AuthGate,
 }
 
 #[derive(Debug)]
@@ -139,7 +140,7 @@ impl From<Error> for ApiError {
     }
 }
 
-pub async fn spawn(config: AppConfig, local_key: SecureKey) -> Result<JoinHandle<()>> {
+pub async fn spawn(config: AppConfig, auth_gate: AuthGate) -> Result<JoinHandle<()>> {
     let addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, config.internal_port));
     let listener = TcpListener::bind(addr).await?;
     info!(
@@ -150,7 +151,7 @@ pub async fn spawn(config: AppConfig, local_key: SecureKey) -> Result<JoinHandle
     let app = Router::new()
         .route("/register", post(register))
         .route("/authenticate", post(authenticate))
-        .with_state(ApiState { local_key });
+        .with_state(ApiState { auth_gate });
 
     Ok(tokio::spawn(async move {
         if let Err(err) = axum::serve(listener, app).await {
@@ -185,9 +186,10 @@ async fn register(
     validate_public_key_info(&request.public_key)?;
 
     let secret_key =
-        key_store::read_temp_secret_key(initialisation_token, &state.local_key).await?;
-    let locally_encrypted_secret_key = secret_key
-        .unlock(|secret_key| key_store::encrypt_aes256_gcm(&state.local_key, secret_key))?;
+        key_store::read_temp_secret_key(initialisation_token, state.auth_gate.local_key()).await?;
+    let locally_encrypted_secret_key = secret_key.unlock(|secret_key| {
+        key_store::encrypt_aes256_gcm(state.auth_gate.local_key(), secret_key)
+    })?;
     let encrypted_secret_key = locally_encrypted_secret_key.unlock_slice(|encrypted| {
         encrypt_with_registration_public_key(&request.public_key, encrypted)
     })?;
@@ -195,7 +197,7 @@ async fn register(
     let registration_json = serde_json::to_vec(&request)
         .map_err(|err| ApiError::internal(format!("failed to serialize registration: {err}")))?;
     let encrypted_registration =
-        key_store::encrypt_aes256_gcm(&state.local_key, &registration_json)?;
+        key_store::encrypt_aes256_gcm(state.auth_gate.local_key(), &registration_json)?;
 
     key_store::store_android_device_registration(
         &request.device_uuid,
@@ -212,12 +214,19 @@ async fn register(
     Ok(StatusCode::NO_CONTENT)
 }
 
-async fn authenticate(Json(request): Json<AuthenticateRequest>) -> StatusCode {
+async fn authenticate(
+    State(state): State<ApiState>,
+    Json(request): Json<AuthenticateRequest>,
+) -> std::result::Result<StatusCode, ApiError> {
     debug!(
-        "Received authentication approval for request {} from {}",
-        request.request_uuid, request.app.package_name
+        "Received authentication approval for request {} from {} on device {}",
+        request.request_uuid, request.app.package_name, request.device_uuid
     );
-    StatusCode::NO_CONTENT
+    state
+        .auth_gate
+        .complete_authentication(&request.request_uuid, &request.decrypted_blob_b64)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 fn validate_public_key_info(public_key: &PublicKeyInfo) -> std::result::Result<(), ApiError> {

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -14,12 +14,11 @@ use rsa::{pkcs8::DecodePublicKey, sha2::Sha256, Oaep, RsaPublicKey};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::{net::TcpListener, task::JoinHandle};
-use uuid::Uuid;
 
 use crate::{
     config::AppConfig,
     error::{Error, Result},
-    key_store::{self, AES256_KEY_BYTES},
+    key_store::{self, SecureBlob, SecureKey},
 };
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
@@ -75,6 +74,7 @@ pub struct DeviceInfo {
 #[serde(deny_unknown_fields)]
 pub struct RegisterRequest {
     pub schema_version: u32,
+    pub device_uuid: String,
     pub keychain: KeychainInfo,
     #[serde(default)]
     pub initialisation_token: Option<String>,
@@ -90,6 +90,7 @@ pub struct RegisterRequest {
 pub struct AuthenticateRequest {
     pub schema_version: u32,
     pub request_uuid: String,
+    pub device_uuid: String,
     pub keychain: KeychainInfo,
     pub decrypted_blob_b64: String,
     pub app: AppInfo,
@@ -98,7 +99,7 @@ pub struct AuthenticateRequest {
 
 #[derive(Clone)]
 struct ApiState {
-    local_key: [u8; AES256_KEY_BYTES],
+    local_key: SecureKey,
 }
 
 #[derive(Debug)]
@@ -138,7 +139,7 @@ impl From<Error> for ApiError {
     }
 }
 
-pub async fn spawn(config: AppConfig, local_key: [u8; AES256_KEY_BYTES]) -> Result<JoinHandle<()>> {
+pub async fn spawn(config: AppConfig, local_key: SecureKey) -> Result<JoinHandle<()>> {
     let addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, config.internal_port));
     let listener = TcpListener::bind(addr).await?;
     info!(
@@ -185,19 +186,19 @@ async fn register(
 
     let secret_key =
         key_store::read_temp_secret_key(initialisation_token, &state.local_key).await?;
-    let locally_encrypted_secret_key =
-        key_store::encrypt_aes256_gcm(&state.local_key, &secret_key)?;
-    let encrypted_secret_key =
-        encrypt_with_registration_public_key(&request.public_key, &locally_encrypted_secret_key)?;
+    let locally_encrypted_secret_key = secret_key
+        .unlock(|secret_key| key_store::encrypt_aes256_gcm(&state.local_key, secret_key))?;
+    let encrypted_secret_key = locally_encrypted_secret_key.unlock_slice(|encrypted| {
+        encrypt_with_registration_public_key(&request.public_key, encrypted)
+    })?;
 
     let registration_json = serde_json::to_vec(&request)
         .map_err(|err| ApiError::internal(format!("failed to serialize registration: {err}")))?;
     let encrypted_registration =
         key_store::encrypt_aes256_gcm(&state.local_key, &registration_json)?;
 
-    let device_uuid = Uuid::new_v4().to_string();
     key_store::store_android_device_registration(
-        &device_uuid,
+        &request.device_uuid,
         &encrypted_registration,
         &encrypted_secret_key,
     )
@@ -205,7 +206,7 @@ async fn register(
 
     info!(
         "Registered Android device {} at device-keys/android/{}",
-        request.device.model, device_uuid
+        request.device.model, request.device_uuid
     );
 
     Ok(StatusCode::NO_CONTENT)
@@ -244,7 +245,7 @@ fn validate_public_key_info(public_key: &PublicKeyInfo) -> std::result::Result<(
 fn encrypt_with_registration_public_key(
     public_key: &PublicKeyInfo,
     plaintext: &[u8],
-) -> std::result::Result<Vec<u8>, ApiError> {
+) -> std::result::Result<SecureBlob, ApiError> {
     let public_key_der = BASE64
         .decode(&public_key.value_b64)
         .map_err(|_| ApiError::bad_request("public_key.value_b64 is not valid base64"))?;
@@ -254,6 +255,7 @@ fn encrypt_with_registration_public_key(
     public_key
         .encrypt(&mut OsRng, Oaep::new::<Sha256>(), plaintext)
         .map_err(|err| ApiError::bad_request(format!("RSA-OAEP-256 encryption failed: {err}")))
+        .and_then(|encrypted| key_store::secure_blob_from_vec(encrypted).map_err(ApiError::from))
 }
 
 #[cfg(test)]
@@ -284,6 +286,7 @@ mod tests {
     fn register_request_parses_expected_payload() {
         let payload = r#"{
             "schema_version": 1,
+            "device_uuid": "f2018f87-e926-42a1-8b48-9ad4b7fd7cde",
             "keychain": {
               "domain": "example.com",
               "port": 443
@@ -320,6 +323,7 @@ mod tests {
 
         let request: RegisterRequest = serde_json::from_str(payload).unwrap();
         assert_eq!(request.schema_version, 1);
+        assert_eq!(request.device_uuid, "f2018f87-e926-42a1-8b48-9ad4b7fd7cde");
         assert_eq!(
             request.initialisation_token.as_deref(),
             Some("optional-token")
@@ -332,6 +336,7 @@ mod tests {
         let payload = r#"{
             "schema_version": 1,
             "request_uuid": "6fbbce84-5aef-43c3-8cc7-469cbfd83109",
+            "device_uuid": "f2018f87-e926-42a1-8b48-9ad4b7fd7cde",
             "keychain": {
               "domain": "example.com",
               "port": 443
@@ -348,6 +353,7 @@ mod tests {
         let request: AuthenticateRequest = serde_json::from_str(payload).unwrap();
         assert_eq!(request.schema_version, 1);
         assert_eq!(request.request_uuid, "6fbbce84-5aef-43c3-8cc7-469cbfd83109");
+        assert_eq!(request.device_uuid, "f2018f87-e926-42a1-8b48-9ad4b7fd7cde");
         assert_eq!(request.decrypted_blob_b64, "base64-decrypted-blob");
     }
 }

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -77,6 +77,7 @@ pub struct RegisterRequest {
     pub schema_version: u32,
     pub device_uuid: String,
     pub keychain: KeychainInfo,
+    pub device_name: String,
     #[serde(default)]
     pub initialisation_token: Option<String>,
     pub public_key: PublicKeyInfo,
@@ -337,6 +338,7 @@ mod tests {
               "domain": "example.com",
               "port": 443
             },
+            "device_name": "Pixel 9",
             "initialisation_token": "optional-token",
             "public_key": {
               "algorithm": "RSA-OAEP-256",

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -1,5 +1,6 @@
 use std::{
-    os::unix::fs::PermissionsExt,
+    io::Write,
+    os::unix::fs::{OpenOptionsExt, PermissionsExt},
     path::{Path, PathBuf},
 };
 
@@ -11,9 +12,12 @@ use cuid2::CuidConstructor;
 use hkdf::Hkdf;
 use qrcode::{render::unicode, QrCode};
 use rand::{rngs::OsRng, RngCore};
+use secure_types::{SecureArray, SecureBytes, SecureString};
 use sha2::Sha256;
 use tokio::{
-    fs::{create_dir_all, metadata, read, read_dir, set_permissions, OpenOptions},
+    fs::{
+        create_dir_all, metadata, read, read_dir, set_permissions, OpenOptions as TokioOpenOptions,
+    },
     io::{self, AsyncWriteExt},
 };
 
@@ -34,9 +38,12 @@ const AES_GCM_NONCE_BYTES: usize = 12;
 const ENCRYPTED_BLOB_MAGIC: &[u8] = b"alohomora-aes256-gcm-v1\0";
 const PAIRING_TOKEN_PREFIX: &str = "alohomora";
 const PAIRING_TOKEN_ID_LEN: u16 = 10;
-#[derive(Debug, Clone)]
+pub type SecureKey = SecureArray<u8, AES256_KEY_BYTES>;
+pub type SecureBlob = SecureBytes;
+
+#[derive(Clone)]
 pub struct StartupKeys {
-    pub local_key: [u8; AES256_KEY_BYTES],
+    pub local_key: SecureKey,
 }
 
 pub async fn initialize(config: &AppConfig) -> Result<StartupKeys> {
@@ -60,7 +67,7 @@ async fn ensure_private_dir(path: &Path) -> Result {
 }
 
 async fn write_private_file(path: &Path, contents: &[u8]) -> Result {
-    let mut file = OpenOptions::new()
+    let mut file = TokioOpenOptions::new()
         .write(true)
         .create(true)
         .truncate(true)
@@ -72,16 +79,28 @@ async fn write_private_file(path: &Path, contents: &[u8]) -> Result {
     Ok(())
 }
 
-async fn read_or_create_local_key(path: &Path) -> Result<[u8; AES256_KEY_BYTES]> {
+fn write_private_secure_file(path: &Path, contents: &SecureBlob) -> Result {
+    contents.unlock_slice(|contents| {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        file.write_all(contents)?;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        Ok(())
+    })
+}
+
+async fn read_or_create_local_key(path: &Path) -> Result<SecureKey> {
     match read(path).await {
-        Ok(bytes) => bytes
-            .try_into()
-            .map_err(|_| Error::EncryptionError("local key must be 32 bytes")),
+        Ok(bytes) => secure_key_from_vec(bytes),
         Err(e) if e.kind() == io::ErrorKind::NotFound => {
             let mut key = [0u8; AES256_KEY_BYTES];
             OsRng.fill_bytes(&mut key);
             write_private_file(path, &key).await?;
-            Ok(key)
+            secure_key_from_array(key)
         }
         Err(e) => Err(e.into()),
     }
@@ -135,7 +154,7 @@ async fn has_temp_pairing_keys(key_dir: &Path) -> Result<bool> {
 
 async fn create_temp_pairing_key(
     key_dir: &Path,
-    local_key: &[u8; AES256_KEY_BYTES],
+    local_key: &SecureKey,
     config: &AppConfig,
 ) -> Result {
     let pairing_token = generate_pairing_token();
@@ -144,13 +163,16 @@ async fn create_temp_pairing_key(
 
     let mut secret_key = [0u8; AES256_KEY_BYTES];
     OsRng.fill_bytes(&mut secret_key);
+    let secret_key = secure_key_from_array(secret_key)?;
 
     let token_key = derive_token_key(&pairing_token.value)?;
 
-    let locally_encrypted = encrypt_aes256_gcm(local_key, &secret_key)?;
-    let token_encrypted = encrypt_aes256_gcm(&token_key, &locally_encrypted)?;
+    let locally_encrypted =
+        secret_key.unlock(|secret_key| encrypt_aes256_gcm(local_key, secret_key))?;
+    let token_encrypted =
+        locally_encrypted.unlock_slice(|encrypted| encrypt_aes256_gcm(&token_key, encrypted))?;
 
-    write_private_file(&temp_dir.join(ENC_SECRET_KEY_FILE), &token_encrypted).await?;
+    write_private_secure_file(&temp_dir.join(ENC_SECRET_KEY_FILE), &token_encrypted)?;
 
     println!("Initial Alohomora pairing token: {}", pairing_token.value);
     print_setup_qr_code(&pairing_token.value, config)?;
@@ -224,33 +246,36 @@ fn print_setup_qr_code(token: &str, config: &AppConfig) -> Result {
     Ok(())
 }
 
-fn derive_token_key(token: &str) -> Result<[u8; AES256_KEY_BYTES]> {
+fn derive_token_key(token: &str) -> Result<SecureKey> {
     let hk = Hkdf::<Sha256>::new(None, token.as_bytes());
     let mut key = [0u8; AES256_KEY_BYTES];
     hk.expand(b"alohomora temp pairing token aes256 key", &mut key)
         .map_err(|_| Error::EncryptionError("failed to derive token key"))?;
-    Ok(key)
+    secure_key_from_array(key)
 }
 
-pub fn encrypt_aes256_gcm(key: &[u8; AES256_KEY_BYTES], plaintext: &[u8]) -> Result<Vec<u8>> {
-    let cipher = Aes256Gcm::new_from_slice(key)
-        .map_err(|_| Error::EncryptionError("invalid AES256 key length"))?;
+pub fn encrypt_aes256_gcm(key: &SecureKey, plaintext: &[u8]) -> Result<SecureBlob> {
+    key.unlock(|key| {
+        let cipher = Aes256Gcm::new_from_slice(key)
+            .map_err(|_| Error::EncryptionError("invalid AES256 key length"))?;
 
-    let mut nonce = [0u8; AES_GCM_NONCE_BYTES];
-    OsRng.fill_bytes(&mut nonce);
+        let mut nonce = [0u8; AES_GCM_NONCE_BYTES];
+        OsRng.fill_bytes(&mut nonce);
 
-    let ciphertext = cipher
-        .encrypt(Nonce::from_slice(&nonce), plaintext)
-        .map_err(|_| Error::EncryptionError("AES256-GCM encryption failed"))?;
+        let ciphertext = cipher
+            .encrypt(Nonce::from_slice(&nonce), plaintext)
+            .map_err(|_| Error::EncryptionError("AES256-GCM encryption failed"))?;
 
-    let mut out = Vec::with_capacity(ENCRYPTED_BLOB_MAGIC.len() + nonce.len() + ciphertext.len());
-    out.extend_from_slice(ENCRYPTED_BLOB_MAGIC);
-    out.extend_from_slice(&nonce);
-    out.extend_from_slice(&ciphertext);
-    Ok(out)
+        let mut out =
+            Vec::with_capacity(ENCRYPTED_BLOB_MAGIC.len() + nonce.len() + ciphertext.len());
+        out.extend_from_slice(ENCRYPTED_BLOB_MAGIC);
+        out.extend_from_slice(&nonce);
+        out.extend_from_slice(&ciphertext);
+        secure_blob_from_vec(out)
+    })
 }
 
-pub fn decrypt_aes256_gcm(key: &[u8; AES256_KEY_BYTES], encrypted: &[u8]) -> Result<Vec<u8>> {
+pub fn decrypt_aes256_gcm(key: &SecureKey, encrypted: &[u8]) -> Result<SecureBlob> {
     if !encrypted.starts_with(ENCRYPTED_BLOB_MAGIC) {
         return Err(Error::EncryptionError("unknown encrypted blob format"));
     }
@@ -261,46 +286,46 @@ pub fn decrypt_aes256_gcm(key: &[u8; AES256_KEY_BYTES], encrypted: &[u8]) -> Res
     }
 
     let (nonce, ciphertext) = encrypted.split_at(AES_GCM_NONCE_BYTES);
-    let cipher = Aes256Gcm::new_from_slice(key)
-        .map_err(|_| Error::EncryptionError("invalid AES256 key length"))?;
-    cipher
-        .decrypt(Nonce::from_slice(nonce), ciphertext)
-        .map_err(|_| Error::EncryptionError("AES256-GCM decryption failed"))
+    key.unlock(|key| {
+        let cipher = Aes256Gcm::new_from_slice(key)
+            .map_err(|_| Error::EncryptionError("invalid AES256 key length"))?;
+        let plaintext = cipher
+            .decrypt(Nonce::from_slice(nonce), ciphertext)
+            .map_err(|_| Error::EncryptionError("AES256-GCM decryption failed"))?;
+        secure_blob_from_vec(plaintext)
+    })
 }
 
-pub async fn read_temp_secret_key(
-    token: &str,
-    local_key: &[u8; AES256_KEY_BYTES],
-) -> Result<[u8; AES256_KEY_BYTES]> {
+pub async fn read_temp_secret_key(token: &str, local_key: &SecureKey) -> Result<SecureKey> {
     let pairing_token = parse_pairing_token(token)?;
     let token_key = derive_token_key(&pairing_token.value)?;
-    let encrypted =
+    let encrypted = secure_blob_from_vec(
         read(temp_pairing_key_dir(Path::new(KEY_DIR), &pairing_token.id).join(ENC_SECRET_KEY_FILE))
-            .await?;
-    let locally_encrypted = decrypt_aes256_gcm(&token_key, &encrypted)?;
-    let secret_key = decrypt_aes256_gcm(local_key, &locally_encrypted)?;
+            .await?,
+    )?;
+    let locally_encrypted =
+        encrypted.unlock_slice(|encrypted| decrypt_aes256_gcm(&token_key, encrypted))?;
+    let secret_key = locally_encrypted
+        .unlock_slice(|locally_encrypted| decrypt_aes256_gcm(local_key, locally_encrypted))?;
 
-    secret_key
-        .try_into()
-        .map_err(|_| Error::EncryptionError("secret key must be 32 bytes"))
+    SecureKey::try_from(secret_key).map_err(secure_memory_error)
 }
 
 pub async fn store_android_device_registration(
     device_uuid: &str,
-    encrypted_registration_json: &[u8],
-    encrypted_secret_key: &[u8],
+    encrypted_registration_json: &SecureBlob,
+    encrypted_secret_key: &SecureBlob,
 ) -> Result {
     let device_dir = Path::new(KEY_DIR)
         .join(DEVICE_KEYS_DIR)
         .join(ANDROID_DEVICE_KEYS_DIR)
         .join(device_uuid);
     ensure_private_dir(&device_dir).await?;
-    write_private_file(
+    write_private_secure_file(
         &device_dir.join(ENC_DEVICE_REGISTRATION_FILE),
         encrypted_registration_json,
-    )
-    .await?;
-    write_private_file(&device_dir.join(ENC_SECRET_KEY_FILE), encrypted_secret_key).await?;
+    )?;
+    write_private_secure_file(&device_dir.join(ENC_SECRET_KEY_FILE), encrypted_secret_key)?;
     Ok(())
 }
 
@@ -308,8 +333,8 @@ fn temp_pairing_key_dir(key_dir: &Path, token_id: &str) -> PathBuf {
     key_dir.join(TEMP_PAIRING_KEYS_DIR).join(token_id)
 }
 
-pub fn key_to_passphrase(key: &[u8; AES256_KEY_BYTES]) -> String {
-    hex_encode(key)
+pub fn key_to_passphrase(key: &SecureKey) -> SecureString {
+    key.unlock(|key| SecureString::from(hex_encode(key)))
 }
 
 fn hex_encode(bytes: &[u8]) -> String {
@@ -320,6 +345,26 @@ fn hex_encode(bytes: &[u8]) -> String {
         output.push(HEX[(byte & 0x0f) as usize] as char);
     }
     output
+}
+
+fn secure_key_from_array(key: [u8; AES256_KEY_BYTES]) -> Result<SecureKey> {
+    let mut key = key;
+    SecureKey::from_slice_mut(&mut key).map_err(secure_memory_error)
+}
+
+fn secure_key_from_vec(bytes: Vec<u8>) -> Result<SecureKey> {
+    let key: [u8; AES256_KEY_BYTES] = bytes
+        .try_into()
+        .map_err(|_| Error::EncryptionError("local key must be 32 bytes"))?;
+    secure_key_from_array(key)
+}
+
+pub fn secure_blob_from_vec(bytes: Vec<u8>) -> Result<SecureBlob> {
+    SecureBlob::from_vec(bytes).map_err(secure_memory_error)
+}
+
+fn secure_memory_error(_: secure_types::Error) -> Error {
+    Error::EncryptionError("secure memory operation failed")
 }
 
 #[cfg(test)]

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -99,16 +99,48 @@ fn write_private_secure_file(path: &Path, contents: &SecureBlob) -> Result {
 }
 
 async fn read_or_create_local_key(path: &Path) -> Result<SecureKey> {
-    match read(path).await {
-        Ok(bytes) => secure_key_from_vec(bytes),
-        Err(e) if e.kind() == io::ErrorKind::NotFound => {
-            let mut key = [0u8; AES256_KEY_BYTES];
-            OsRng.fill_bytes(&mut key);
-            write_private_file(path, &key).await?;
-            secure_key_from_array(key)
+    if let Ok(cred_dir) = std::env::var("CREDENTIALS_DIRECTORY") {
+        let cred_path = Path::new(&cred_dir).join("local_key.bin");
+        if cred_path.exists() {
+            match read(&cred_path).await {
+                Ok(bytes) => return secure_key_from_vec(bytes),
+                Err(e) => {
+                    log::warn!("Failed to read credential from systemd path {:?}: {}", cred_path, e);
+                }
+            }
         }
-        Err(e) => Err(e.into()),
     }
+
+    // Generate a new local key inside a SecureKey type
+    let mut key = [0u8; AES256_KEY_BYTES];
+    OsRng.fill_bytes(&mut key);
+    let secure_key = secure_key_from_array(key)?;
+
+    // Encrypt the new key using systemd-creds by piping to stdin
+    let mut child = std::process::Command::new("systemd-creds")
+        .args(["encrypt", "--name=local_key.bin", "-", "-"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|_| Error::EncryptionError("failed to spawn systemd-creds"))?;
+
+    secure_key.unlock(|key_bytes| {
+        if let Some(stdin) = child.stdin.as_mut() {
+            stdin.write_all(key_bytes).map_err(|_| Error::EncryptionError("failed to write key to systemd-creds stdin"))?;
+        }
+        Ok::<(), Error>(())
+    })?;
+
+    let output = child.wait_with_output().map_err(|_| Error::EncryptionError("failed to wait for systemd-creds"))?;
+    if !output.status.success() {
+        return Err(Error::EncryptionError("systemd-creds encryption failed"));
+    }
+
+    // Write the encrypted output from stdout to the target path
+    write_private_file(path, &output.stdout).await?;
+
+    Ok(secure_key)
 }
 
 async fn has_existing_pairing_keys(key_dir: &Path) -> Result<bool> {
@@ -424,5 +456,33 @@ mod tests {
     #[test]
     fn pairing_token_rejects_bad_format() {
         assert!(parse_pairing_token("alohomora-not-valid").is_err());
+    }
+
+    #[tokio::test]
+    async fn test_read_or_create_local_key_systemd_creds() {
+        let temp_file = std::env::temp_dir().join(format!("test_local_key_{}.bin", nanoid::nanoid!()));
+
+        // 1. Generate local key (which will encrypt it using systemd-creds)
+        match super::read_or_create_local_key(&temp_file).await {
+            Ok(key) => {
+                assert!(temp_file.exists());
+
+                // 2. Read it back using systemd-creds decrypt to verify it works
+                let output = std::process::Command::new("systemd-creds")
+                    .args(["decrypt", "--name=local_key.bin", temp_file.to_str().unwrap(), "-"])
+                    .output()
+                    .unwrap();
+                assert!(output.status.success());
+                key.unlock(|key_bytes| {
+                    assert_eq!(output.stdout, key_bytes);
+                });
+
+                // 3. Clean up
+                let _ = std::fs::remove_file(temp_file);
+            }
+            Err(e) => {
+                println!("Skipping test: systemd-creds not fully configured or lacks permissions on this host: {:?}", e);
+            }
+        }
     }
 }

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 
 const KEY_DIR: &str = "/var/lib/alohomora-service";
-const LOCAL_KEY_FILE: &str = "local_key.bin";
+pub const LOCAL_KEY_FILE: &str = "local_key.bin";
 const DEVICE_KEYS_DIR: &str = "device-keys";
 const ANDROID_DEVICE_KEYS_DIR: &str = "android";
 const TEMP_PAIRING_KEYS_DIR: &str = "temp-pairing-keys";
@@ -107,7 +107,7 @@ pub async fn initialize(_config: &AppConfig) -> Result<StartupKeys> {
     Ok(StartupKeys { local_key })
 }
 
-pub async fn run_setup(config: &AppConfig) -> Result {
+pub async fn run_setup(config: &AppConfig) -> Result<bool> {
     let key_dir = get_key_dir();
     ensure_private_dir(&key_dir).await?;
 
@@ -119,12 +119,11 @@ pub async fn run_setup(config: &AppConfig) -> Result {
 
     if !has_existing_pairing_keys(&key_dir).await? {
         create_temp_pairing_key(&key_dir, &local_key, config).await?;
-        println!("Setup completed successfully.");
+        Ok(true)
     } else {
         println!("Setup already completed.");
+        Ok(false)
     }
-
-    Ok(())
 }
 
 async fn ensure_private_dir(path: &Path) -> Result {

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -461,6 +461,28 @@ pub async fn list_android_device_auth_blobs() -> Result<Vec<AndroidDeviceAuthBlo
     Ok(devices)
 }
 
+pub async fn clear_secret_store() -> Result {
+    let key_dir = get_key_dir();
+    if key_dir.exists() {
+        log::info!("Deleting key directory: {:?}", key_dir);
+        tokio::fs::remove_dir_all(&key_dir).await?;
+    }
+
+    let pass_dir = std::env::var("PASSWORD_STORE_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            let home = std::env::var("HOME").expect("$HOME must be set");
+            std::path::Path::new(&home).join(".password-store")
+        });
+    let secret_service_dir = pass_dir.join("secret-service");
+    if secret_service_dir.exists() {
+        log::info!("Deleting secret-service directory from password store: {:?}", secret_service_dir);
+        tokio::fs::remove_dir_all(&secret_service_dir).await?;
+    }
+
+    Ok(())
+}
+
 fn temp_pairing_key_dir(key_dir: &Path, token_id: &str) -> PathBuf {
     key_dir.join(TEMP_PAIRING_KEYS_DIR).join(token_id)
 }
@@ -626,5 +648,49 @@ mod tests {
 
         // Clean up temp dir files
         let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[tokio::test]
+    async fn test_clear_secret_store_removes_directories() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let temp_dir = std::env::temp_dir().join(format!("test_key_dir_{}", nanoid::nanoid!()));
+        let temp_pass_dir = std::env::temp_dir().join(format!("test_pass_dir_{}", nanoid::nanoid!()));
+        let temp_secret_service_dir = temp_pass_dir.join("secret-service");
+
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        std::fs::create_dir_all(&temp_secret_service_dir).unwrap();
+
+        let original_key_dir = std::env::var("ALOHOMORA_KEY_DIR").ok();
+        let original_pass_dir = std::env::var("PASSWORD_STORE_DIR").ok();
+
+        std::env::set_var("ALOHOMORA_KEY_DIR", &temp_dir);
+        std::env::set_var("PASSWORD_STORE_DIR", &temp_pass_dir);
+
+        // Verify directories exist
+        assert!(temp_dir.exists());
+        assert!(temp_secret_service_dir.exists());
+
+        // Perform the clear logic
+        let clear_result = super::clear_secret_store().await;
+        assert!(clear_result.is_ok());
+
+        // Verify directories are gone
+        assert!(!temp_dir.exists());
+        assert!(!temp_secret_service_dir.exists());
+
+        // Clean up env vars
+        if let Some(val) = original_key_dir {
+            std::env::set_var("ALOHOMORA_KEY_DIR", val);
+        } else {
+            std::env::remove_var("ALOHOMORA_KEY_DIR");
+        }
+        if let Some(val) = original_pass_dir {
+            std::env::set_var("PASSWORD_STORE_DIR", val);
+        } else {
+            std::env::remove_var("PASSWORD_STORE_DIR");
+        }
+
+        // Clean up temp dirs
+        let _ = std::fs::remove_dir_all(&temp_pass_dir);
     }
 }

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -1,10 +1,15 @@
-use std::{os::unix::fs::PermissionsExt, path::Path};
+use std::{
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+};
 
 use aes_gcm::{
     aead::{Aead, KeyInit},
     Aes256Gcm, Nonce,
 };
+use cuid2::CuidConstructor;
 use hkdf::Hkdf;
+use qrcode::{render::unicode, QrCode};
 use rand::{rngs::OsRng, RngCore};
 use sha2::Sha256;
 use tokio::{
@@ -12,23 +17,29 @@ use tokio::{
     io::{self, AsyncWriteExt},
 };
 
-use crate::error::{Error, Result};
+use crate::{
+    config::AppConfig,
+    error::{Error, Result},
+};
 
 const KEY_DIR: &str = "/var/lib/alohomora-service";
 const LOCAL_KEY_FILE: &str = "local_key.bin";
 const DEVICE_KEYS_DIR: &str = "device-keys";
+const ANDROID_DEVICE_KEYS_DIR: &str = "android";
 const TEMP_PAIRING_KEYS_DIR: &str = "temp-pairing-keys";
 const ENC_SECRET_KEY_FILE: &str = "enc_secret_key.bin";
-const AES256_KEY_BYTES: usize = 32;
+const ENC_DEVICE_REGISTRATION_FILE: &str = "enc_device_registration.json";
+pub const AES256_KEY_BYTES: usize = 32;
 const AES_GCM_NONCE_BYTES: usize = 12;
 const ENCRYPTED_BLOB_MAGIC: &[u8] = b"alohomora-aes256-gcm-v1\0";
-
+const PAIRING_TOKEN_PREFIX: &str = "alohomora";
+const PAIRING_TOKEN_ID_LEN: u16 = 10;
 #[derive(Debug, Clone)]
 pub struct StartupKeys {
     pub local_key: [u8; AES256_KEY_BYTES],
 }
 
-pub async fn initialize() -> Result<StartupKeys> {
+pub async fn initialize(config: &AppConfig) -> Result<StartupKeys> {
     let key_dir = Path::new(KEY_DIR);
     ensure_private_dir(key_dir).await?;
 
@@ -36,7 +47,7 @@ pub async fn initialize() -> Result<StartupKeys> {
     let local_key = read_or_create_local_key(&local_key_path).await?;
 
     if !has_existing_pairing_keys(key_dir).await? {
-        create_temp_pairing_key(key_dir, &local_key).await?;
+        create_temp_pairing_key(key_dir, &local_key, config).await?;
     }
 
     Ok(StartupKeys { local_key })
@@ -81,7 +92,7 @@ async fn has_existing_pairing_keys(key_dir: &Path) -> Result<bool> {
 }
 
 async fn has_device_keys(key_dir: &Path) -> Result<bool> {
-    let android_dir = key_dir.join(DEVICE_KEYS_DIR).join("android");
+    let android_dir = key_dir.join(DEVICE_KEYS_DIR).join(ANDROID_DEVICE_KEYS_DIR);
     let mut entries = match read_dir(android_dir).await {
         Ok(entries) => entries,
         Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
@@ -102,43 +113,115 @@ async fn has_device_keys(key_dir: &Path) -> Result<bool> {
 }
 
 async fn has_temp_pairing_keys(key_dir: &Path) -> Result<bool> {
-    match metadata(
-        key_dir
-            .join(TEMP_PAIRING_KEYS_DIR)
-            .join(ENC_SECRET_KEY_FILE),
-    )
-    .await
-    {
-        Ok(_) => Ok(true),
-        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
-        Err(e) => Err(e.into()),
+    let temp_dir = key_dir.join(TEMP_PAIRING_KEYS_DIR);
+    let mut entries = match read_dir(temp_dir).await {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(e.into()),
+    };
+
+    while let Some(entry) = entries.next_entry().await? {
+        if entry.file_type().await?.is_dir() {
+            match metadata(entry.path().join(ENC_SECRET_KEY_FILE)).await {
+                Ok(_) => return Ok(true),
+                Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
     }
+
+    Ok(false)
 }
 
-async fn create_temp_pairing_key(key_dir: &Path, local_key: &[u8; AES256_KEY_BYTES]) -> Result {
-    let temp_dir = key_dir.join(TEMP_PAIRING_KEYS_DIR);
+async fn create_temp_pairing_key(
+    key_dir: &Path,
+    local_key: &[u8; AES256_KEY_BYTES],
+    config: &AppConfig,
+) -> Result {
+    let pairing_token = generate_pairing_token();
+    let temp_dir = temp_pairing_key_dir(key_dir, &pairing_token.id);
     ensure_private_dir(&temp_dir).await?;
 
     let mut secret_key = [0u8; AES256_KEY_BYTES];
     OsRng.fill_bytes(&mut secret_key);
 
-    let token = generate_pairing_token();
-    let token_key = derive_token_key(&token)?;
+    let token_key = derive_token_key(&pairing_token.value)?;
 
     let locally_encrypted = encrypt_aes256_gcm(local_key, &secret_key)?;
     let token_encrypted = encrypt_aes256_gcm(&token_key, &locally_encrypted)?;
 
     write_private_file(&temp_dir.join(ENC_SECRET_KEY_FILE), &token_encrypted).await?;
 
-    println!("Initial Alohomora pairing token: {token}");
+    println!("Initial Alohomora pairing token: {}", pairing_token.value);
+    print_setup_qr_code(&pairing_token.value, config)?;
 
     Ok(())
 }
 
-fn generate_pairing_token() -> String {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PairingToken {
+    pub id: String,
+    pub value: String,
+}
+
+fn generate_pairing_token() -> PairingToken {
+    let id = CuidConstructor::new()
+        .with_length(PAIRING_TOKEN_ID_LEN)
+        .create_id();
     let mut token_bytes = [0u8; AES256_KEY_BYTES];
     OsRng.fill_bytes(&mut token_bytes);
-    format!("alohomora-{}", hex_encode(&token_bytes))
+    let encoded_token = bs58::encode(token_bytes).into_string();
+    let value = format!("{PAIRING_TOKEN_PREFIX}-{id}-{encoded_token}");
+    PairingToken { id, value }
+}
+
+pub fn parse_pairing_token(token: &str) -> Result<PairingToken> {
+    let mut parts = token.splitn(3, '-');
+    let prefix = parts.next();
+    let id = parts.next();
+    let encoded_token = parts.next();
+
+    let (Some(PAIRING_TOKEN_PREFIX), Some(id), Some(encoded_token)) = (prefix, id, encoded_token)
+    else {
+        return Err(Error::InvalidRequest("invalid pairing token format".into()));
+    };
+
+    if id.len() != PAIRING_TOKEN_ID_LEN as usize || !cuid2::is_cuid2(id) {
+        return Err(Error::InvalidRequest("invalid pairing token id".into()));
+    }
+
+    let token_bytes = bs58::decode(encoded_token)
+        .into_vec()
+        .map_err(|_| Error::InvalidRequest("invalid pairing token encoding".into()))?;
+    if token_bytes.len() != AES256_KEY_BYTES {
+        return Err(Error::InvalidRequest(
+            "invalid pairing token entropy length".into(),
+        ));
+    }
+
+    Ok(PairingToken {
+        id: id.to_owned(),
+        value: token.to_owned(),
+    })
+}
+
+fn print_setup_qr_code(token: &str, config: &AppConfig) -> Result {
+    let setup_url = format!(
+        "https://alohomora.app/register?d={}&p={}&t={token}",
+        config.domain, config.external_port
+    );
+    let qr_code =
+        QrCode::new(setup_url.as_bytes()).map_err(|_| Error::EncryptionError("invalid QR data"))?;
+    let qr = qr_code
+        .render::<unicode::Dense1x2>()
+        .dark_color(unicode::Dense1x2::Dark)
+        .light_color(unicode::Dense1x2::Light)
+        .build();
+
+    println!("Initial Alohomora setup URL: {setup_url}");
+    println!("{qr}");
+
+    Ok(())
 }
 
 fn derive_token_key(token: &str) -> Result<[u8; AES256_KEY_BYTES]> {
@@ -149,7 +232,7 @@ fn derive_token_key(token: &str) -> Result<[u8; AES256_KEY_BYTES]> {
     Ok(key)
 }
 
-fn encrypt_aes256_gcm(key: &[u8; AES256_KEY_BYTES], plaintext: &[u8]) -> Result<Vec<u8>> {
+pub fn encrypt_aes256_gcm(key: &[u8; AES256_KEY_BYTES], plaintext: &[u8]) -> Result<Vec<u8>> {
     let cipher = Aes256Gcm::new_from_slice(key)
         .map_err(|_| Error::EncryptionError("invalid AES256 key length"))?;
 
@@ -167,6 +250,64 @@ fn encrypt_aes256_gcm(key: &[u8; AES256_KEY_BYTES], plaintext: &[u8]) -> Result<
     Ok(out)
 }
 
+pub fn decrypt_aes256_gcm(key: &[u8; AES256_KEY_BYTES], encrypted: &[u8]) -> Result<Vec<u8>> {
+    if !encrypted.starts_with(ENCRYPTED_BLOB_MAGIC) {
+        return Err(Error::EncryptionError("unknown encrypted blob format"));
+    }
+
+    let encrypted = &encrypted[ENCRYPTED_BLOB_MAGIC.len()..];
+    if encrypted.len() < AES_GCM_NONCE_BYTES {
+        return Err(Error::EncryptionError("encrypted blob missing nonce"));
+    }
+
+    let (nonce, ciphertext) = encrypted.split_at(AES_GCM_NONCE_BYTES);
+    let cipher = Aes256Gcm::new_from_slice(key)
+        .map_err(|_| Error::EncryptionError("invalid AES256 key length"))?;
+    cipher
+        .decrypt(Nonce::from_slice(nonce), ciphertext)
+        .map_err(|_| Error::EncryptionError("AES256-GCM decryption failed"))
+}
+
+pub async fn read_temp_secret_key(
+    token: &str,
+    local_key: &[u8; AES256_KEY_BYTES],
+) -> Result<[u8; AES256_KEY_BYTES]> {
+    let pairing_token = parse_pairing_token(token)?;
+    let token_key = derive_token_key(&pairing_token.value)?;
+    let encrypted =
+        read(temp_pairing_key_dir(Path::new(KEY_DIR), &pairing_token.id).join(ENC_SECRET_KEY_FILE))
+            .await?;
+    let locally_encrypted = decrypt_aes256_gcm(&token_key, &encrypted)?;
+    let secret_key = decrypt_aes256_gcm(local_key, &locally_encrypted)?;
+
+    secret_key
+        .try_into()
+        .map_err(|_| Error::EncryptionError("secret key must be 32 bytes"))
+}
+
+pub async fn store_android_device_registration(
+    device_uuid: &str,
+    encrypted_registration_json: &[u8],
+    encrypted_secret_key: &[u8],
+) -> Result {
+    let device_dir = Path::new(KEY_DIR)
+        .join(DEVICE_KEYS_DIR)
+        .join(ANDROID_DEVICE_KEYS_DIR)
+        .join(device_uuid);
+    ensure_private_dir(&device_dir).await?;
+    write_private_file(
+        &device_dir.join(ENC_DEVICE_REGISTRATION_FILE),
+        encrypted_registration_json,
+    )
+    .await?;
+    write_private_file(&device_dir.join(ENC_SECRET_KEY_FILE), encrypted_secret_key).await?;
+    Ok(())
+}
+
+fn temp_pairing_key_dir(key_dir: &Path, token_id: &str) -> PathBuf {
+    key_dir.join(TEMP_PAIRING_KEYS_DIR).join(token_id)
+}
+
 pub fn key_to_passphrase(key: &[u8; AES256_KEY_BYTES]) -> String {
     hex_encode(key)
 }
@@ -179,4 +320,26 @@ fn hex_encode(bytes: &[u8]) -> String {
         output.push(HEX[(byte & 0x0f) as usize] as char);
     }
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{generate_pairing_token, parse_pairing_token, PAIRING_TOKEN_PREFIX};
+
+    #[test]
+    fn pairing_token_contains_cuid_and_base58_entropy() {
+        let token = generate_pairing_token();
+        let parsed = parse_pairing_token(&token.value).unwrap();
+
+        assert_eq!(parsed.id, token.id);
+        assert_eq!(parsed.value, token.value);
+        assert!(token
+            .value
+            .starts_with(&format!("{PAIRING_TOKEN_PREFIX}-{}-", token.id)));
+    }
+
+    #[test]
+    fn pairing_token_rejects_bad_format() {
+        assert!(parse_pairing_token("alohomora-not-valid").is_err());
+    }
 }

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -1,0 +1,182 @@
+use std::{os::unix::fs::PermissionsExt, path::Path};
+
+use aes_gcm::{
+    aead::{Aead, KeyInit},
+    Aes256Gcm, Nonce,
+};
+use hkdf::Hkdf;
+use rand::{rngs::OsRng, RngCore};
+use sha2::Sha256;
+use tokio::{
+    fs::{create_dir_all, metadata, read, read_dir, set_permissions, OpenOptions},
+    io::{self, AsyncWriteExt},
+};
+
+use crate::error::{Error, Result};
+
+const KEY_DIR: &str = "/var/lib/alohomora-service";
+const LOCAL_KEY_FILE: &str = "local_key.bin";
+const DEVICE_KEYS_DIR: &str = "device-keys";
+const TEMP_PAIRING_KEYS_DIR: &str = "temp-pairing-keys";
+const ENC_SECRET_KEY_FILE: &str = "enc_secret_key.bin";
+const AES256_KEY_BYTES: usize = 32;
+const AES_GCM_NONCE_BYTES: usize = 12;
+const ENCRYPTED_BLOB_MAGIC: &[u8] = b"alohomora-aes256-gcm-v1\0";
+
+#[derive(Debug, Clone)]
+pub struct StartupKeys {
+    pub local_key: [u8; AES256_KEY_BYTES],
+}
+
+pub async fn initialize() -> Result<StartupKeys> {
+    let key_dir = Path::new(KEY_DIR);
+    ensure_private_dir(key_dir).await?;
+
+    let local_key_path = key_dir.join(LOCAL_KEY_FILE);
+    let local_key = read_or_create_local_key(&local_key_path).await?;
+
+    if !has_existing_pairing_keys(key_dir).await? {
+        create_temp_pairing_key(key_dir, &local_key).await?;
+    }
+
+    Ok(StartupKeys { local_key })
+}
+
+async fn ensure_private_dir(path: &Path) -> Result {
+    create_dir_all(path).await?;
+    set_permissions(path, std::fs::Permissions::from_mode(0o700)).await?;
+    Ok(())
+}
+
+async fn write_private_file(path: &Path, contents: &[u8]) -> Result {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .await?;
+    file.write_all(contents).await?;
+    set_permissions(path, std::fs::Permissions::from_mode(0o600)).await?;
+    Ok(())
+}
+
+async fn read_or_create_local_key(path: &Path) -> Result<[u8; AES256_KEY_BYTES]> {
+    match read(path).await {
+        Ok(bytes) => bytes
+            .try_into()
+            .map_err(|_| Error::EncryptionError("local key must be 32 bytes")),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            let mut key = [0u8; AES256_KEY_BYTES];
+            OsRng.fill_bytes(&mut key);
+            write_private_file(path, &key).await?;
+            Ok(key)
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+async fn has_existing_pairing_keys(key_dir: &Path) -> Result<bool> {
+    Ok(has_device_keys(key_dir).await? || has_temp_pairing_keys(key_dir).await?)
+}
+
+async fn has_device_keys(key_dir: &Path) -> Result<bool> {
+    let android_dir = key_dir.join(DEVICE_KEYS_DIR).join("android");
+    let mut entries = match read_dir(android_dir).await {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(e.into()),
+    };
+
+    while let Some(entry) = entries.next_entry().await? {
+        if entry.file_type().await?.is_dir() {
+            match metadata(entry.path().join(ENC_SECRET_KEY_FILE)).await {
+                Ok(_) => return Ok(true),
+                Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+async fn has_temp_pairing_keys(key_dir: &Path) -> Result<bool> {
+    match metadata(
+        key_dir
+            .join(TEMP_PAIRING_KEYS_DIR)
+            .join(ENC_SECRET_KEY_FILE),
+    )
+    .await
+    {
+        Ok(_) => Ok(true),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e.into()),
+    }
+}
+
+async fn create_temp_pairing_key(key_dir: &Path, local_key: &[u8; AES256_KEY_BYTES]) -> Result {
+    let temp_dir = key_dir.join(TEMP_PAIRING_KEYS_DIR);
+    ensure_private_dir(&temp_dir).await?;
+
+    let mut secret_key = [0u8; AES256_KEY_BYTES];
+    OsRng.fill_bytes(&mut secret_key);
+
+    let token = generate_pairing_token();
+    let token_key = derive_token_key(&token)?;
+
+    let locally_encrypted = encrypt_aes256_gcm(local_key, &secret_key)?;
+    let token_encrypted = encrypt_aes256_gcm(&token_key, &locally_encrypted)?;
+
+    write_private_file(&temp_dir.join(ENC_SECRET_KEY_FILE), &token_encrypted).await?;
+
+    println!("Initial Alohomora pairing token: {token}");
+
+    Ok(())
+}
+
+fn generate_pairing_token() -> String {
+    let mut token_bytes = [0u8; AES256_KEY_BYTES];
+    OsRng.fill_bytes(&mut token_bytes);
+    format!("alohomora-{}", hex_encode(&token_bytes))
+}
+
+fn derive_token_key(token: &str) -> Result<[u8; AES256_KEY_BYTES]> {
+    let hk = Hkdf::<Sha256>::new(None, token.as_bytes());
+    let mut key = [0u8; AES256_KEY_BYTES];
+    hk.expand(b"alohomora temp pairing token aes256 key", &mut key)
+        .map_err(|_| Error::EncryptionError("failed to derive token key"))?;
+    Ok(key)
+}
+
+fn encrypt_aes256_gcm(key: &[u8; AES256_KEY_BYTES], plaintext: &[u8]) -> Result<Vec<u8>> {
+    let cipher = Aes256Gcm::new_from_slice(key)
+        .map_err(|_| Error::EncryptionError("invalid AES256 key length"))?;
+
+    let mut nonce = [0u8; AES_GCM_NONCE_BYTES];
+    OsRng.fill_bytes(&mut nonce);
+
+    let ciphertext = cipher
+        .encrypt(Nonce::from_slice(&nonce), plaintext)
+        .map_err(|_| Error::EncryptionError("AES256-GCM encryption failed"))?;
+
+    let mut out = Vec::with_capacity(ENCRYPTED_BLOB_MAGIC.len() + nonce.len() + ciphertext.len());
+    out.extend_from_slice(ENCRYPTED_BLOB_MAGIC);
+    out.extend_from_slice(&nonce);
+    out.extend_from_slice(&ciphertext);
+    Ok(out)
+}
+
+pub fn key_to_passphrase(key: &[u8; AES256_KEY_BYTES]) -> String {
+    hex_encode(key)
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -46,6 +46,11 @@ pub struct StartupKeys {
     pub local_key: SecureKey,
 }
 
+pub struct AndroidDeviceAuthBlob {
+    pub device_uuid: String,
+    pub encrypted_secret_key: SecureBlob,
+}
+
 pub async fn initialize(config: &AppConfig) -> Result<StartupKeys> {
     let key_dir = Path::new(KEY_DIR);
     ensure_private_dir(key_dir).await?;
@@ -327,6 +332,39 @@ pub async fn store_android_device_registration(
     )?;
     write_private_secure_file(&device_dir.join(ENC_SECRET_KEY_FILE), encrypted_secret_key)?;
     Ok(())
+}
+
+pub async fn list_android_device_auth_blobs() -> Result<Vec<AndroidDeviceAuthBlob>> {
+    let android_dir = Path::new(KEY_DIR)
+        .join(DEVICE_KEYS_DIR)
+        .join(ANDROID_DEVICE_KEYS_DIR);
+    let mut entries = match read_dir(android_dir).await {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e.into()),
+    };
+    let mut devices = Vec::new();
+
+    while let Some(entry) = entries.next_entry().await? {
+        if !entry.file_type().await?.is_dir() {
+            continue;
+        }
+
+        let device_uuid = entry.file_name().to_string_lossy().into_owned();
+        let encrypted_secret_key_path = entry.path().join(ENC_SECRET_KEY_FILE);
+        let encrypted_secret_key = match read(encrypted_secret_key_path).await {
+            Ok(bytes) => secure_blob_from_vec(bytes)?,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e.into()),
+        };
+
+        devices.push(AndroidDeviceAuthBlob {
+            device_uuid,
+            encrypted_secret_key,
+        });
+    }
+
+    Ok(devices)
 }
 
 fn temp_pairing_key_dir(key_dir: &Path, token_id: &str) -> PathBuf {

--- a/src/key_store.rs
+++ b/src/key_store.rs
@@ -51,18 +51,80 @@ pub struct AndroidDeviceAuthBlob {
     pub encrypted_secret_key: SecureBlob,
 }
 
-pub async fn initialize(config: &AppConfig) -> Result<StartupKeys> {
-    let key_dir = Path::new(KEY_DIR);
-    ensure_private_dir(key_dir).await?;
+pub fn get_key_dir() -> PathBuf {
+    std::env::var("ALOHOMORA_KEY_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(KEY_DIR))
+}
 
+pub async fn read_local_key(path: &Path) -> Result<Option<SecureKey>> {
+    if let Ok(cred_dir) = std::env::var("CREDENTIALS_DIRECTORY") {
+        let cred_path = Path::new(&cred_dir).join("local_key.bin");
+        if cred_path.exists() {
+            match read(&cred_path).await {
+                Ok(bytes) => return Ok(Some(secure_key_from_vec(bytes)?)),
+                Err(e) => {
+                    log::warn!("Failed to read credential from systemd path {:?}: {}", cred_path, e);
+                }
+            }
+        }
+    }
+
+    if path.exists() {
+        let output = std::process::Command::new("systemd-creds")
+            .args(["decrypt", "--name=local_key.bin", path.to_str().unwrap(), "-"])
+            .output();
+        match output {
+            Ok(out) if out.status.success() => {
+                return Ok(Some(secure_key_from_vec(out.stdout)?));
+            }
+            Ok(out) => {
+                log::warn!(
+                    "systemd-creds decryption failed with exit code {:?}, stderr: {}",
+                    out.status.code(),
+                    String::from_utf8_lossy(&out.stderr)
+                );
+            }
+            Err(e) => {
+                log::warn!("Failed to run systemd-creds decrypt on {:?}: {}", path, e);
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+pub async fn initialize(_config: &AppConfig) -> Result<StartupKeys> {
+    let key_dir = get_key_dir();
     let local_key_path = key_dir.join(LOCAL_KEY_FILE);
-    let local_key = read_or_create_local_key(&local_key_path).await?;
+    let local_key = read_local_key(&local_key_path).await?
+        .ok_or(Error::SetupIncomplete)?;
 
-    if !has_existing_pairing_keys(key_dir).await? {
-        create_temp_pairing_key(key_dir, &local_key, config).await?;
+    if !has_existing_pairing_keys(&key_dir).await? {
+        return Err(Error::SetupIncomplete);
     }
 
     Ok(StartupKeys { local_key })
+}
+
+pub async fn run_setup(config: &AppConfig) -> Result {
+    let key_dir = get_key_dir();
+    ensure_private_dir(&key_dir).await?;
+
+    let local_key_path = key_dir.join(LOCAL_KEY_FILE);
+    let local_key = match read_local_key(&local_key_path).await? {
+        Some(key) => key,
+        None => read_or_create_local_key(&local_key_path).await?,
+    };
+
+    if !has_existing_pairing_keys(&key_dir).await? {
+        create_temp_pairing_key(&key_dir, &local_key, config).await?;
+        println!("Setup completed successfully.");
+    } else {
+        println!("Setup already completed.");
+    }
+
+    Ok(())
 }
 
 async fn ensure_private_dir(path: &Path) -> Result {
@@ -337,7 +399,7 @@ pub async fn read_temp_secret_key(token: &str, local_key: &SecureKey) -> Result<
     let pairing_token = parse_pairing_token(token)?;
     let token_key = derive_token_key(&pairing_token.value)?;
     let encrypted = secure_blob_from_vec(
-        read(temp_pairing_key_dir(Path::new(KEY_DIR), &pairing_token.id).join(ENC_SECRET_KEY_FILE))
+        read(temp_pairing_key_dir(&get_key_dir(), &pairing_token.id).join(ENC_SECRET_KEY_FILE))
             .await?,
     )?;
     let locally_encrypted =
@@ -353,7 +415,7 @@ pub async fn store_android_device_registration(
     encrypted_registration_json: &SecureBlob,
     encrypted_secret_key: &SecureBlob,
 ) -> Result {
-    let device_dir = Path::new(KEY_DIR)
+    let device_dir = get_key_dir()
         .join(DEVICE_KEYS_DIR)
         .join(ANDROID_DEVICE_KEYS_DIR)
         .join(device_uuid);
@@ -367,7 +429,7 @@ pub async fn store_android_device_registration(
 }
 
 pub async fn list_android_device_auth_blobs() -> Result<Vec<AndroidDeviceAuthBlob>> {
-    let android_dir = Path::new(KEY_DIR)
+    let android_dir = get_key_dir()
         .join(DEVICE_KEYS_DIR)
         .join(ANDROID_DEVICE_KEYS_DIR);
     let mut entries = match read_dir(android_dir).await {
@@ -484,5 +546,85 @@ mod tests {
                 println!("Skipping test: systemd-creds not fully configured or lacks permissions on this host: {:?}", e);
             }
         }
+    }
+
+    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[tokio::test]
+    async fn test_initialize_fails_when_setup_incomplete() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let temp_dir = std::env::temp_dir().join(format!("test_key_dir_{}", nanoid::nanoid!()));
+        let original_env = std::env::var("ALOHOMORA_KEY_DIR").ok();
+        std::env::set_var("ALOHOMORA_KEY_DIR", &temp_dir);
+
+        let config = crate::config::AppConfig {
+            domain: "test.com".to_string(),
+            external_port: 12345,
+            internal_port: 12345,
+        };
+
+        let result = super::initialize(&config).await;
+        assert!(matches!(result, Err(crate::error::Error::SetupIncomplete)));
+
+        if let Some(val) = original_env {
+            std::env::set_var("ALOHOMORA_KEY_DIR", val);
+        } else {
+            std::env::remove_var("ALOHOMORA_KEY_DIR");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_setup_and_initialize_flow() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let temp_dir = std::env::temp_dir().join(format!("test_key_dir_{}", nanoid::nanoid!()));
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        // Write local_key.bin to temp_dir to act as CREDENTIALS_DIRECTORY
+        let mock_key = [7u8; 32];
+        let cred_file_path = temp_dir.join("local_key.bin");
+        std::fs::write(&cred_file_path, &mock_key).unwrap();
+
+        let original_key_dir = std::env::var("ALOHOMORA_KEY_DIR").ok();
+        let original_cred_dir = std::env::var("CREDENTIALS_DIRECTORY").ok();
+
+        std::env::set_var("ALOHOMORA_KEY_DIR", &temp_dir);
+        std::env::set_var("CREDENTIALS_DIRECTORY", &temp_dir);
+
+        let config = crate::config::AppConfig {
+            domain: "test.com".to_string(),
+            external_port: 12345,
+            internal_port: 12345,
+        };
+
+        // 1. Initially, initialize should fail because pairing keys don't exist yet
+        let init_result = super::initialize(&config).await;
+        assert!(matches!(init_result, Err(crate::error::Error::SetupIncomplete)));
+
+        // 2. Run setup
+        let setup_result = super::run_setup(&config).await;
+        assert!(setup_result.is_ok());
+
+        // 3. Now, initialize should succeed and read the correct key
+        let init_success = super::initialize(&config).await;
+        assert!(init_success.is_ok());
+        let startup_keys = init_success.unwrap();
+        startup_keys.local_key.unlock(|key_bytes| {
+            assert_eq!(key_bytes, &mock_key);
+        });
+
+        // Clean up env vars
+        if let Some(val) = original_key_dir {
+            std::env::set_var("ALOHOMORA_KEY_DIR", val);
+        } else {
+            std::env::remove_var("ALOHOMORA_KEY_DIR");
+        }
+        if let Some(val) = original_cred_dir {
+            std::env::set_var("CREDENTIALS_DIRECTORY", val);
+        } else {
+            std::env::remove_var("CREDENTIALS_DIRECTORY");
+        }
+
+        // Clean up temp dir files
+        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,171 @@
+use cli::CliArgs;
+use dbus_server::service::Service;
+use jiff::{
+    fmt::{friendly::SpanPrinter, rfc2822},
+    tz::TimeZone,
+    SignedDuration, Timestamp, Zoned,
+};
+use log::{debug, error, info};
+use pass::PasswordStore;
+use zbus::{zvariant::Optional, Connection};
+
+use crate::{
+    auth_gate::AuthGate,
+    cli::{CliSubcommand, LastAccessorSubcommand},
+    dbus_server::{service::DEFAULT_COLLECTION_NAME, SecretAccessor},
+    error::Result,
+};
+
+pub mod auth_gate;
+pub mod cli;
+pub mod config;
+pub mod dbus_server;
+pub mod error;
+pub mod http_server;
+pub mod key_store;
+pub mod pass;
+pub mod secret_store;
+
+// Constants from the spec
+const WELL_KNOWN_NAME: &'static str = "org.freedesktop.secrets";
+const BASE_PATH: &'static str = "/org/freedesktop/secrets";
+
+pub async fn run(args: CliArgs) -> Result {
+    match args.subcommand {
+        None | Some(CliSubcommand::RunService(_)) => {
+            // None = no subcommand given. Default is to run service
+
+            let config = config::AppConfig::from_env()?;
+            let startup_keys = key_store::initialize(&config).await?;
+            let symmetric_gpg_passphrase = key_store::key_to_passphrase(&startup_keys.local_key);
+            let auth_gate = AuthGate::new(&config, startup_keys.local_key);
+            let pass = Box::leak(Box::new(PasswordStore::from_env(
+                args.password_store_dir.map(|d| d.into()),
+                symmetric_gpg_passphrase,
+            )?));
+            let _http_server = http_server::spawn(config, auth_gate.clone()).await?;
+
+            let connection = Connection::session().await?;
+
+            info!(
+                "D-Bus session connection established. Unique name: {}",
+                connection.unique_name().map(|s| s.as_str()).unwrap_or("?")
+            );
+
+            let service = Service::init(
+                connection.clone(),
+                pass,
+                auth_gate,
+                args.forget_password_on_lock,
+                args.notify_on_access,
+            )
+            .await?;
+
+            connection.object_server().at(BASE_PATH, service).await?;
+
+            connection.request_name(WELL_KNOWN_NAME).await?;
+
+            info!("Acquired well-known name: `{}`", WELL_KNOWN_NAME);
+
+            loop {
+                std::future::pending::<()>().await;
+            }
+        }
+        Some(CliSubcommand::LastAccessor(LastAccessorSubcommand {
+            collection,
+            id,
+            alias,
+        })) => {
+            let connection = Connection::session().await?;
+
+            // debug because this isn't really relevant for just fetching info
+            debug!(
+                "D-Bus session connection established. Unique name: {}",
+                connection.unique_name().map(|s| s.as_str()).unwrap_or("?")
+            );
+
+            // collection takes precedence, default _alias_ used if neither provided
+            let collection_specifier_type = if collection.is_some() {
+                "collection"
+            } else {
+                "aliases"
+            };
+
+            // collection takes precendence over alias
+            let collection_alias_name = collection
+                .or(alias)
+                .unwrap_or_else(|| DEFAULT_COLLECTION_NAME.into());
+
+            let secret_path = format!("{collection_specifier_type}/{collection_alias_name}/{id}");
+            // call last_access
+            let call_result = connection
+                .call_method(
+                    Some(WELL_KNOWN_NAME),
+                    format!("{BASE_PATH}/{secret_path}"),
+                    Some("org.freedesktop.Secret.Item"),
+                    "LastAccess",
+                    &(),
+                )
+                .await;
+            let method_body = match call_result {
+                Ok(m) => m,
+                // print friendly error mesasage for unknown objecdt
+                Err(zbus::Error::MethodError(e, _, _))
+                    if e == "org.freedesktop.DBus.Error.UnknownObject" =>
+                {
+                    error!("No secret found at {secret_path}");
+                    return Ok(());
+                }
+                Err(e) => {
+                    return Err(dbg!(e).into());
+                }
+            };
+            let body = method_body.body();
+            let accessor: Option<SecretAccessor> =
+                body.deserialize::<Optional<SecretAccessor>>()?.into();
+
+            match accessor {
+                None => {
+                    info!("No programs have accessed {secret_path} since the service started.")
+                }
+                Some(SecretAccessor {
+                    uid,
+                    username,
+                    pid,
+                    process_name,
+                    timestamp,
+                    ..
+                }) => {
+                    // create a zoned struct for formatting
+                    let orig = Zoned::new(
+                        Timestamp::from_millisecond(timestamp).unwrap(),
+                        TimeZone::system(),
+                    );
+                    let diff =
+                        SignedDuration::from_millis(timestamp - Timestamp::now().as_millisecond());
+                    info!(
+                        "The last access of {secret_path} was {}:",
+                        SpanPrinter::new().duration_to_string(&diff)
+                    );
+                    info!(
+                        "  User: {} (UID {uid})",
+                        username
+                            .as_ref()
+                            .map(|s| &s[..])
+                            .unwrap_or_else(|| "<unknown>")
+                    );
+                    info!(
+                        "  Program: {} (PID {pid})",
+                        process_name
+                            .as_ref()
+                            .map(|s| &s[..])
+                            .unwrap_or_else(|| "<unknown>")
+                    );
+                    info!("  Timestamp: {}", rfc2822::to_string(&orig).unwrap());
+                }
+            };
+
+            Ok(())
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use crate::{
 mod cli;
 mod dbus_server;
 mod error;
+mod key_store;
 mod pass;
 mod secret_store;
 
@@ -33,8 +34,11 @@ async fn run(args: CliArgs) -> Result {
         None | Some(CliSubcommand::RunService(_)) => {
             // None = no subcommand given. Default is to run service
 
+            let startup_keys = key_store::initialize().await?;
+            let symmetric_gpg_passphrase = key_store::key_to_passphrase(&startup_keys.local_key);
             let pass = Box::leak(Box::new(PasswordStore::from_env(
                 args.password_store_dir.map(|d| d.into()),
+                symmetric_gpg_passphrase,
             )?));
 
             let connection = Connection::session().await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,197 +1,25 @@
 use std::process::ExitCode;
-
-use cli::CliArgs;
-use dbus_server::service::Service;
-use env_logger::Env;
-use jiff::{
-    fmt::{friendly::SpanPrinter, rfc2822},
-    tz::TimeZone,
-    SignedDuration, Timestamp, Zoned,
-};
-use log::{debug, error, info};
-use pass::PasswordStore;
-use zbus::{zvariant::Optional, Connection};
-
-use crate::{
-    auth_gate::AuthGate,
-    cli::{CliSubcommand, LastAccessorSubcommand},
-    dbus_server::{service::DEFAULT_COLLECTION_NAME, SecretAccessor},
-    error::Result,
-};
-
-mod auth_gate;
-mod cli;
-mod config;
-mod dbus_server;
-mod error;
-mod http_server;
-mod key_store;
-mod pass;
-mod secret_store;
-
-// Constants from the spec
-const WELL_KNOWN_NAME: &'static str = "org.freedesktop.secrets";
-const BASE_PATH: &'static str = "/org/freedesktop/secrets";
-
-async fn run(args: CliArgs) -> Result {
-    match args.subcommand {
-        None | Some(CliSubcommand::RunService(_)) => {
-            // None = no subcommand given. Default is to run service
-
-            let config = config::AppConfig::from_env()?;
-            let startup_keys = key_store::initialize(&config).await?;
-            let symmetric_gpg_passphrase = key_store::key_to_passphrase(&startup_keys.local_key);
-            let auth_gate = AuthGate::new(&config, startup_keys.local_key);
-            let pass = Box::leak(Box::new(PasswordStore::from_env(
-                args.password_store_dir.map(|d| d.into()),
-                symmetric_gpg_passphrase,
-            )?));
-            let _http_server = http_server::spawn(config, auth_gate.clone()).await?;
-
-            let connection = Connection::session().await?;
-
-            info!(
-                "D-Bus session connection established. Unique name: {}",
-                connection.unique_name().map(|s| s.as_str()).unwrap_or("?")
-            );
-
-            let service = Service::init(
-                connection.clone(),
-                pass,
-                auth_gate,
-                args.forget_password_on_lock,
-                args.notify_on_access,
-            )
-            .await?;
-
-            connection.object_server().at(BASE_PATH, service).await?;
-
-            connection.request_name(WELL_KNOWN_NAME).await?;
-
-            info!("Acquired well-known name: `{}`", WELL_KNOWN_NAME);
-
-            loop {
-                std::future::pending::<()>().await;
-            }
-        }
-        Some(CliSubcommand::LastAccessor(LastAccessorSubcommand {
-            collection,
-            id,
-            alias,
-        })) => {
-            let connection = Connection::session().await?;
-
-            // debug because this isn't really relevant for just fetching info
-            debug!(
-                "D-Bus session connection established. Unique name: {}",
-                connection.unique_name().map(|s| s.as_str()).unwrap_or("?")
-            );
-
-            // collection takes precedence, default _alias_ used if neither provided
-            let collection_specifier_type = if collection.is_some() {
-                "collection"
-            } else {
-                "aliases"
-            };
-
-            // collection takes precendence over alias
-            let collection_alias_name = collection
-                .or(alias)
-                .unwrap_or_else(|| DEFAULT_COLLECTION_NAME.into());
-
-            let secret_path = format!("{collection_specifier_type}/{collection_alias_name}/{id}");
-            // call last_access
-            let call_result = connection
-                .call_method(
-                    Some(WELL_KNOWN_NAME),
-                    format!("{BASE_PATH}/{secret_path}"),
-                    Some("org.freedesktop.Secret.Item"),
-                    "LastAccess",
-                    &(),
-                )
-                .await;
-            let method_body = match call_result {
-                Ok(m) => m,
-                // print friendly error mesasage for unknown objecdt
-                Err(zbus::Error::MethodError(e, _, _))
-                    if e == "org.freedesktop.DBus.Error.UnknownObject" =>
-                {
-                    error!("No secret found at {secret_path}");
-                    return Ok(());
-                }
-                Err(e) => {
-                    return Err(dbg!(e).into());
-                }
-            };
-            let body = method_body.body();
-            let accessor: Option<SecretAccessor> =
-                body.deserialize::<Optional<SecretAccessor>>()?.into();
-
-            match accessor {
-                None => {
-                    info!("No programs have accessed {secret_path} since the service started.")
-                }
-                Some(SecretAccessor {
-                    uid,
-                    username,
-                    pid,
-                    process_name,
-                    timestamp,
-                    ..
-                }) => {
-                    // create a zoned struct for formatting
-                    let orig = Zoned::new(
-                        Timestamp::from_millisecond(timestamp).unwrap(),
-                        TimeZone::system(),
-                    );
-                    let diff =
-                        SignedDuration::from_millis(timestamp - Timestamp::now().as_millisecond());
-                    info!(
-                        "The last access of {secret_path} was {}:",
-                        SpanPrinter::new().duration_to_string(&diff)
-                    );
-                    info!(
-                        "  User: {} (UID {uid})",
-                        username
-                            .as_ref()
-                            .map(|s| &s[..])
-                            .unwrap_or_else(|| "<unknown>")
-                    );
-                    info!(
-                        "  Program: {} (PID {pid})",
-                        process_name
-                            .as_ref()
-                            .map(|s| &s[..])
-                            .unwrap_or_else(|| "<unknown>")
-                    );
-                    info!("  Timestamp: {}", rfc2822::to_string(&orig).unwrap());
-                }
-            };
-
-            Ok(())
-        }
-    }
-}
+use pass_secret_service::{cli, run};
 
 #[tokio::main]
 async fn main() -> ExitCode {
-    let args: CliArgs = argh::from_env();
+    let args: cli::CliArgs = argh::from_env();
 
     // if the environment variable isn't set, fallback to the cli arg, and use info if that isn't set
     env_logger::Builder::from_env(
-        Env::default().default_filter_or(args.log_level.as_deref().unwrap_or("info")),
+        env_logger::Env::default().default_filter_or(args.log_level.as_deref().unwrap_or("info")),
     )
     .init();
 
     if args.print_version {
         // print the current crate version and exit
-        info!("pass-secret-service v{}", env!("CARGO_PKG_VERSION"));
+        log::info!("pass-secret-service v{}", env!("CARGO_PKG_VERSION"));
         return ExitCode::SUCCESS;
     }
 
     // handle any startup errors cleanly
     if let Err(err) = run(args).await {
-        error!("{}", err);
+        log::error!("{}", err);
         ExitCode::FAILURE
     } else {
         ExitCode::SUCCESS

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,7 @@ async fn run(args: CliArgs) -> Result {
                 }
                 Some(SecretAccessor {
                     uid,
+                    username,
                     pid,
                     process_name,
                     timestamp,
@@ -137,7 +138,13 @@ async fn run(args: CliArgs) -> Result {
                         "The last access of {secret_path} was {}:",
                         SpanPrinter::new().duration_to_string(&diff)
                     );
-                    info!("  User: {uid}");
+                    info!(
+                        "  User: {} (UID {uid})",
+                        username
+                            .as_ref()
+                            .map(|s| &s[..])
+                            .unwrap_or_else(|| "<unknown>")
+                    );
                     info!(
                         "  Program: {} (PID {pid})",
                         process_name

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,10 @@ use crate::{
 };
 
 mod cli;
+mod config;
 mod dbus_server;
 mod error;
+mod http_server;
 mod key_store;
 mod pass;
 mod secret_store;
@@ -34,12 +36,14 @@ async fn run(args: CliArgs) -> Result {
         None | Some(CliSubcommand::RunService(_)) => {
             // None = no subcommand given. Default is to run service
 
-            let startup_keys = key_store::initialize().await?;
+            let config = config::AppConfig::from_env()?;
+            let startup_keys = key_store::initialize(&config).await?;
             let symmetric_gpg_passphrase = key_store::key_to_passphrase(&startup_keys.local_key);
             let pass = Box::leak(Box::new(PasswordStore::from_env(
                 args.password_store_dir.map(|d| d.into()),
                 symmetric_gpg_passphrase,
             )?));
+            let _http_server = http_server::spawn(config, startup_keys.local_key).await?;
 
             let connection = Connection::session().await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,11 +13,13 @@ use pass::PasswordStore;
 use zbus::{zvariant::Optional, Connection};
 
 use crate::{
+    auth_gate::AuthGate,
     cli::{CliSubcommand, LastAccessorSubcommand},
     dbus_server::{service::DEFAULT_COLLECTION_NAME, SecretAccessor},
     error::Result,
 };
 
+mod auth_gate;
 mod cli;
 mod config;
 mod dbus_server;
@@ -39,11 +41,12 @@ async fn run(args: CliArgs) -> Result {
             let config = config::AppConfig::from_env()?;
             let startup_keys = key_store::initialize(&config).await?;
             let symmetric_gpg_passphrase = key_store::key_to_passphrase(&startup_keys.local_key);
+            let auth_gate = AuthGate::new(&config, startup_keys.local_key);
             let pass = Box::leak(Box::new(PasswordStore::from_env(
                 args.password_store_dir.map(|d| d.into()),
                 symmetric_gpg_passphrase,
             )?));
-            let _http_server = http_server::spawn(config, startup_keys.local_key).await?;
+            let _http_server = http_server::spawn(config, auth_gate.clone()).await?;
 
             let connection = Connection::session().await?;
 
@@ -55,6 +58,7 @@ async fn run(args: CliArgs) -> Result {
             let service = Service::init(
                 connection.clone(),
                 pass,
+                auth_gate,
                 args.forget_password_on_lock,
                 args.notify_on_access,
             )

--- a/src/pass.rs
+++ b/src/pass.rs
@@ -16,7 +16,10 @@ use tokio::{
     process::Command,
 };
 
-use crate::error::{Error, Result};
+use crate::{
+    error::{Error, Result},
+    key_store::{self, SecureKey},
+};
 
 pub struct PasswordStore {
     pub directory: PathBuf,
@@ -105,7 +108,14 @@ impl PasswordStore {
     }
 
     fn add_symmetric_passphrase_args<'a>(&self, command: &'a mut Command) -> &'a mut Command {
-        self.symmetric_gpg_passphrase.unlock_str(|passphrase| {
+        Self::add_symmetric_passphrase_args_with(command, &self.symmetric_gpg_passphrase)
+    }
+
+    fn add_symmetric_passphrase_args_with<'a>(
+        command: &'a mut Command,
+        passphrase: &SecureString,
+    ) -> &'a mut Command {
+        passphrase.unlock_str(|passphrase| {
             command
                 .arg("--batch")
                 .arg("--yes")
@@ -123,11 +133,29 @@ impl PasswordStore {
         path: impl AsRef<Path>,
         _can_prompt: bool,
     ) -> Result<Vec<u8>> {
+        self.read_password_with_passphrase(path, &self.symmetric_gpg_passphrase)
+            .await
+    }
+
+    pub async fn read_password_with_key(
+        &self,
+        path: impl AsRef<Path>,
+        key: &SecureKey,
+    ) -> Result<Vec<u8>> {
+        let passphrase = key_store::key_to_passphrase(key);
+        self.read_password_with_passphrase(path, &passphrase).await
+    }
+
+    async fn read_password_with_passphrase(
+        &self,
+        path: impl AsRef<Path>,
+        passphrase: &SecureString,
+    ) -> Result<Vec<u8>> {
         let contents = read(self.get_full_secret_path(path)).await?;
 
         let mut command = self.make_gpg_process();
 
-        self.add_symmetric_passphrase_args(&mut command);
+        Self::add_symmetric_passphrase_args_with(&mut command, passphrase);
 
         command.arg("--decrypt").arg("-");
 

--- a/src/pass.rs
+++ b/src/pass.rs
@@ -17,19 +17,21 @@ use tokio::{
 
 use crate::error::{Error, Result};
 
-const SYMMETRIC_GPG_PASSPHRASE: &str = "pass-secret-service-proof-passphrase";
-
 #[derive(Debug)]
 pub struct PasswordStore {
     pub directory: PathBuf,
     gpg_opts: Option<String>,
+    symmetric_gpg_passphrase: String,
     file_mode: u32,
     dir_mode: u32,
 }
 
 impl PasswordStore {
     /// Initialize this PasswordStore instance from env vars
-    pub fn from_env(password_store_dir: Option<PathBuf>) -> Result<Self> {
+    pub fn from_env(
+        password_store_dir: Option<PathBuf>,
+        symmetric_gpg_passphrase: String,
+    ) -> Result<Self> {
         let mut env: HashMap<String, String> = env::vars().collect();
 
         // Either ~/.password-store or $PASSWORD_STORE_DIR
@@ -57,6 +59,7 @@ impl PasswordStore {
         Ok(Self {
             directory,
             gpg_opts,
+            symmetric_gpg_passphrase,
             dir_mode,
             file_mode,
         })
@@ -90,14 +93,14 @@ impl PasswordStore {
         command
     }
 
-    fn add_symmetric_passphrase_args(command: &mut Command) -> &mut Command {
+    fn add_symmetric_passphrase_args<'a>(&self, command: &'a mut Command) -> &'a mut Command {
         command
             .arg("--batch")
             .arg("--yes")
             .arg("--pinentry-mode")
             .arg("loopback")
             .arg("--passphrase")
-            .arg(SYMMETRIC_GPG_PASSPHRASE)
+            .arg(&self.symmetric_gpg_passphrase)
             .arg("--no-symkey-cache")
     }
 
@@ -111,7 +114,7 @@ impl PasswordStore {
 
         let mut command = self.make_gpg_process();
 
-        Self::add_symmetric_passphrase_args(&mut command);
+        self.add_symmetric_passphrase_args(&mut command);
 
         command.arg("--decrypt").arg("-");
 
@@ -173,7 +176,7 @@ impl PasswordStore {
         self.ensure_dirs(dir).await?;
 
         let mut command = self.make_gpg_process();
-        Self::add_symmetric_passphrase_args(&mut command);
+        self.add_symmetric_passphrase_args(&mut command);
 
         let mut process = command
             .arg("--symmetric")

--- a/src/pass.rs
+++ b/src/pass.rs
@@ -1,6 +1,7 @@
+use secure_types::SecureString;
 use std::{
     collections::{HashMap, HashSet},
-    env,
+    env, fmt,
     fs::{FileType, Metadata},
     io::{self, ErrorKind},
     path::{Path, PathBuf},
@@ -17,20 +18,30 @@ use tokio::{
 
 use crate::error::{Error, Result};
 
-#[derive(Debug)]
 pub struct PasswordStore {
     pub directory: PathBuf,
     gpg_opts: Option<String>,
-    symmetric_gpg_passphrase: String,
+    symmetric_gpg_passphrase: SecureString,
     file_mode: u32,
     dir_mode: u32,
+}
+
+impl fmt::Debug for PasswordStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PasswordStore")
+            .field("directory", &self.directory)
+            .field("gpg_opts", &self.gpg_opts)
+            .field("file_mode", &self.file_mode)
+            .field("dir_mode", &self.dir_mode)
+            .finish_non_exhaustive()
+    }
 }
 
 impl PasswordStore {
     /// Initialize this PasswordStore instance from env vars
     pub fn from_env(
         password_store_dir: Option<PathBuf>,
-        symmetric_gpg_passphrase: String,
+        symmetric_gpg_passphrase: SecureString,
     ) -> Result<Self> {
         let mut env: HashMap<String, String> = env::vars().collect();
 
@@ -94,14 +105,16 @@ impl PasswordStore {
     }
 
     fn add_symmetric_passphrase_args<'a>(&self, command: &'a mut Command) -> &'a mut Command {
-        command
-            .arg("--batch")
-            .arg("--yes")
-            .arg("--pinentry-mode")
-            .arg("loopback")
-            .arg("--passphrase")
-            .arg(&self.symmetric_gpg_passphrase)
-            .arg("--no-symkey-cache")
+        self.symmetric_gpg_passphrase.unlock_str(|passphrase| {
+            command
+                .arg("--batch")
+                .arg("--yes")
+                .arg("--pinentry-mode")
+                .arg("loopback")
+                .arg("--passphrase")
+                .arg(passphrase)
+                .arg("--no-symkey-cache")
+        })
     }
 
     /// Read a single password at the given path

--- a/src/pass.rs
+++ b/src/pass.rs
@@ -17,6 +17,8 @@ use tokio::{
 
 use crate::error::{Error, Result};
 
+const SYMMETRIC_GPG_PASSPHRASE: &str = "pass-secret-service-proof-passphrase";
+
 #[derive(Debug)]
 pub struct PasswordStore {
     pub directory: PathBuf,
@@ -88,16 +90,28 @@ impl PasswordStore {
         command
     }
 
+    fn add_symmetric_passphrase_args(command: &mut Command) -> &mut Command {
+        command
+            .arg("--batch")
+            .arg("--yes")
+            .arg("--pinentry-mode")
+            .arg("loopback")
+            .arg("--passphrase")
+            .arg(SYMMETRIC_GPG_PASSPHRASE)
+            .arg("--no-symkey-cache")
+    }
+
     /// Read a single password at the given path
-    pub async fn read_password(&self, path: impl AsRef<Path>, can_prompt: bool) -> Result<Vec<u8>> {
+    pub async fn read_password(
+        &self,
+        path: impl AsRef<Path>,
+        _can_prompt: bool,
+    ) -> Result<Vec<u8>> {
         let contents = read(self.get_full_secret_path(path)).await?;
 
         let mut command = self.make_gpg_process();
 
-        if !can_prompt {
-            // don't activate pinentry if we can't prompt
-            command.arg("--pinentry-mode=error");
-        }
+        Self::add_symmetric_passphrase_args(&mut command);
 
         command.arg("--decrypt").arg("-");
 
@@ -158,16 +172,13 @@ impl PasswordStore {
 
         self.ensure_dirs(dir).await?;
 
-        let gpg_ids = self.get_gpg_ids(dir).await?;
+        let mut command = self.make_gpg_process();
+        Self::add_symmetric_passphrase_args(&mut command);
 
-        let mut process = self
-            .make_gpg_process()
-            .arg("--encrypt")
-            .args(
-                gpg_ids
-                    .into_iter()
-                    .map(|recipient| format!("--recipient={recipient}")),
-            )
+        let mut process = command
+            .arg("--symmetric")
+            .arg("--cipher-algo")
+            .arg("AES256")
             .arg("-")
             .spawn()?;
 

--- a/src/secret_store/mod.rs
+++ b/src/secret_store/mod.rs
@@ -9,7 +9,7 @@ use std::{
 use async_trait::async_trait;
 use dyn_clone::DynClone;
 
-use crate::{error::Result, pass::PasswordStore};
+use crate::{error::Result, key_store::SecureKey, pass::PasswordStore};
 
 pub mod redb;
 mod redb_imps;
@@ -88,6 +88,12 @@ pub trait SecretStore<'a>: Debug + DynClone {
         collection_id: &str,
         secret_id: &str,
         can_prompt: bool,
+    ) -> Result<Vec<u8>>;
+    async fn read_secret_with_key(
+        &self,
+        collection_id: &str,
+        secret_id: &str,
+        key: &SecureKey,
     ) -> Result<Vec<u8>>;
     async fn read_secret_attrs(
         &self,

--- a/src/secret_store/redb.rs
+++ b/src/secret_store/redb.rs
@@ -9,6 +9,7 @@ use tokio::{sync::RwLock, task::spawn_blocking};
 
 use crate::{
     error::{raise_nonexistent_table, IntoResult, OptionNoneNotFound, Result},
+    key_store::SecureKey,
     pass::PasswordStore,
     secret_store::{redb_imps::RedbHashMap, slugify, SecretStore, NANOID_ALPHABET, PASS_SUBDIR},
 };
@@ -477,6 +478,17 @@ impl<'a> SecretStore<'a> for RedbSecretStore<'a> {
         let secret_path = Path::new(PASS_SUBDIR).join(collection_id).join(secret_id);
 
         Ok(self.pass.read_password(secret_path, can_prompt).await?)
+    }
+
+    async fn read_secret_with_key(
+        &self,
+        collection_id: &str,
+        secret_id: &str,
+        key: &SecureKey,
+    ) -> Result<Vec<u8>> {
+        let secret_path = Path::new(PASS_SUBDIR).join(collection_id).join(secret_id);
+
+        Ok(self.pass.read_password_with_key(secret_path, key).await?)
     }
 
     /// read the attributes for the given secret

--- a/systemd/pass-secret-service.service
+++ b/systemd/pass-secret-service.service
@@ -6,4 +6,5 @@ PartOf=graphical-session.target
 Type=dbus
 BusName=org.freedesktop.secrets
 Environment="PASSWORD_STORE_GPG_OPTS=--cipher-algo AES256"
+LoadCredentialEncrypted=-local_key.bin:/var/lib/alohomora-service/local_key.bin
 ExecStart=/usr/bin/pass-secret-service

--- a/systemd/pass-secret-service.service
+++ b/systemd/pass-secret-service.service
@@ -5,4 +5,5 @@ PartOf=graphical-session.target
 [Service]
 Type=dbus
 BusName=org.freedesktop.secrets
+Environment="PASSWORD_STORE_GPG_OPTS=--cipher-algo AES256"
 ExecStart=/usr/bin/pass-secret-service


### PR DESCRIPTION
- **Apply rustfmt to secret transfer**
- **Use symmetric AES256 GPG storage**
- **Include usernames in secret access metadata**
- **Initialize local key material on startup**
- **Add pairing token registration flow**
- **Store key material in secure types**
- **Add authentication gate for secret reads**
- **use systemd secrets to store local key securely**
- **Ignore .antigravitycli**
- **Move setup logic to separate alohomora-setup executable**
- **Add --clear flag with interactive confirmation prompt to alohomora-setup**
- **Update default domain to agent.lukegt.com**
- **Refactor registration endpoint to be hosted by setup binary instead of service**
- **Prefix HTTP routing endpoints with /alohomora/**
- **Add device_name field to RegisterRequest to match app payload schema**
